### PR TITLE
fix: AuthZ hardening - Action/Workflow/retry/user scoping + the group-approval machine-token ruling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,11 +141,14 @@ behaviour, never "simplify" onto framework defaults.
 
 ## Known Current-State Hazards
 
-**Post-Phase-3 (2026-08-21).** Most entries below are struck through — E2/E4/E7 fixed them. They are
-kept rather than deleted because the strike-throughs record *how* each was fixed, and a fresh session
-that reads a v4-era description as current will chase a bug that no longer exists. **Live hazards are
-the two un-struck entries: the `SecurityInterceptor` soft-fail flip, and the security-off identity
-decision.** Two accepted limitations sit outside this list: the outbox creation-loss window
+**Post-Phase-3 (2026-08-21).** Most entries below are struck through — E2/E4/E7 fixed them, and the
+feat-v5-authz slice closed the four enforcement-era authz gaps (Action get scoping, Workflow create
+guard, engine-retry ownership, `/user/{userId}` self-vs-admin). Entries are kept rather than deleted
+because the strike-throughs record *how* each was fixed, and a fresh session that reads a stale
+description as current will chase a bug that no longer exists. **Still open: the
+`WorkspaceWorkflowService.submit` path-team edge (benign-leaning, see the retry entry) and the
+machine-token approval item (see the Action entry) — the latter awaits a product ruling.** Two
+accepted limitations sit outside this list: the outbox creation-loss window
 (`entity-diff-v4-v5.md` §7) and worker leases (AM-3) — both deliberately deferred, not hazards.
 
 - ~~`SecurityInterceptor` soft-fails permission checks~~ **ENFORCED (2026-08-31, ruled — no
@@ -157,6 +160,19 @@ decision.** Two accepted limitations sit outside this list: the outbox creation-
   `SecurityInterceptor` at the endpoint.
 - ~~The relationship JGraphT singleton (authz bug under N instances)~~ **FIXED (E6,
   2026-07-23)**: direct-query anchored walk, replica-parity proven by test.
+- ~~`ActionService.get(team, id)` had no relationship call~~ **FIXED (feat-v5-authz)**: it was
+  `findById → convert → return`, so any authenticated caller could read any workspace's approval
+  by id. It now applies the same `check(WORKFLOW, workflowRef)` the mutation path (`action`, :103)
+  already used, refusing with the same `ACTION_INVALID_REF` as not-found (no existence oracle);
+  `query`/`summary` already narrowed through `filter()` and are unchanged. Pinned by
+  `ActionWorkspaceAuthorizationTest`. (The separate machine-token approval item — only users can
+  process Actions, per the TODO on `ActionService.action` — stays OPEN awaiting a product ruling.)
+- ~~`WorkflowService.create(team, …)` wrote the `HAS_WORKFLOW` ownership edge before any workspace
+  check~~ **FIXED (feat-v5-authz)**: `check(WORKSPACE, team)` → `PERMISSION_DENIED` now sits at the
+  top of `create`, mirroring the sibling `TaskService.create`, before the entity save and
+  `createNodeAndEdge`. Every create-shaped route funnels through this one method — `apply` and
+  `composeApply` (when the Workflow does not exist yet) and `duplicate` — so the single guard
+  covers all four. Pinned by `WorkflowCreateAuthorizationTest`.
 - **`check()` ignores the workspace path segment for `global`-scope tokens — NOT an authz hole**
   (raised 2026-08-21 as a security finding; **corrected by the maintainer 2026-08-24 — a global
   token doing everything is what global scope is for, so this is not a privilege escalation**).
@@ -172,15 +188,22 @@ decision.** Two accepted limitations sit outside this list: the outbox creation-
   the Workflow's `HAS_WORKFLOW` parent) **before** the retried run is created, so an unresolvable
   owner refuses with `TEAM_INVALID_REF` rather than throwing after the clone is already queued. The
   other six call sites read or mutate the run and write no ownership, so they were unaffected.
-  **Two same-shaped items remain open, both pre-existing (confirmed against `feat-v5-track8`)**:
-  `WorkspaceWorkflowService.submit` still writes the edge from the path team, and the engine's
-  auto-retry (`WorkflowExecutionService:265`) writes no ownership edge at all — so an auto-retried
-  run appears in `/query` (which filters on `workflowRef`) but fails `check()` on `GET /{id}`.
+  ~~The engine's auto-retry (`WorkflowExecutionService:265`) writes no ownership edge at all~~
+  **FIXED (feat-v5-authz)**: the ownership-edge write moved down into the unscoped
+  `WorkflowRunService.retry(workflowRunId, start, retryCount)` itself — resolved via the existing
+  `owningWorkspace` fallback BEFORE the clone is created, written before it is queued — so user
+  retries and engine auto-retries produce identically-owned runs through one path. Deliberate
+  asymmetry, pinned by `WorkflowRunRetryOwnerTest`: the scoped `retry(team, id)` keeps refuse-first
+  (`TEAM_INVALID_REF` before anything is created), while the engine path logs and retries
+  ownerless when no workspace owns the run or its Workflow — recovery is never failed over graph
+  bookkeeping. **Still open, same-shaped and pre-existing**: `WorkspaceWorkflowService.submit`
+  writes the edge from the path team — benign-leaning because `submit` resolves through
+  `filter()`, which applies workspace containment even for global scope (pinned in
+  `WorkflowWorkspaceAuthorizationTest`), so the path team always actually contains the Workflow.
   **Historical note on why it waited**: these were pass-through guards in
   `api/WorkspaceWorkflowRunService`
   over `engine/WorkflowRunService`, and the F1/F2/F3 merge-cleanup collapses the two into one
-  service — at which point `team` either becomes authoritative or disappears. Fix the edge-owner
-  bug as part of that work rather than patching a line about to be deleted.
+  service — at which point `team` either becomes authoritative or disappears.
 - ~~Agent endpoints (`AgentControllerV1`) are unauthenticated~~ **FIXED (E7-4)**: `/api/v1/agent`
   was replaced by `/api/v1/dispatcher` (no dual-serve) behind `DispatcherAuthFilter` — interim
   static bearer token. The first-class Flow dispatcher token (`AuthScope`/`TokenActorKind`,
@@ -426,8 +449,13 @@ uncommented) and `WorkflowAdvancedDetail` rendering `boomerang.io/workflow-ref=u
 
 The `SecurityInterceptor` enforcement flip is **DONE (2026-08-31, feat-v5-track10)** and the
 security-off identity is **RULED** (synthetic virtual admin, never persisted — see
-`specifications/authentication.md`). Still open: `PATCH`/`DELETE /user/{userId}` are gated only
-on global `user/write`/`user/delete` with **no self-scoping** — a backend authz gap now live
-under real enforcement.
+`specifications/authentication.md`). ~~Still open: `PATCH`/`DELETE /user/{userId}` are gated only
+on global `user/write`/`user/delete` with **no self-scoping**~~ **FIXED (feat-v5-authz)**:
+`UserService.apply`/`delete` permit self on principal equality and otherwise require a
+**global-scoped** `user/<action>` grant — the interceptor's `@AuthCriteria` match is scope-blind,
+so a workspace editor/owner's `**/write`/`**/**` used to reach ANY user's account; now only the
+platform admin/operator roles (the only global-scope shapes `resolvePermissionsForUser` issues)
+and explicitly minted `global` tokens do. Pinned by `UserSelfServiceAuthorizationTest`, which also
+pins the `Optional.of(null)` NPE fix (update-by-email of a non-existent user is `USER_NOT_FOUND`).
 
 Item-level detail + dispositions: `specifications/e4-review-findings.md`.

--- a/service-core/src/main/java/io/boomerang/core/UserService.java
+++ b/service-core/src/main/java/io/boomerang/core/UserService.java
@@ -12,6 +12,9 @@ import io.boomerang.common.error.BoomerangError;
 import io.boomerang.common.error.BoomerangException;
 import io.boomerang.core.security.IdentityService;
 import io.boomerang.core.security.UnauthenticatedGlobalToken;
+import io.boomerang.core.security.enums.PermissionAction;
+import io.boomerang.core.security.enums.PermissionResource;
+import io.boomerang.core.security.enums.PermissionScope;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
@@ -452,15 +455,22 @@ public class UserService {
 
   /*
    * Update User
+   *
+   * Self-service or admin-grade only. The update-by-email shape carries no target id, so it is
+   * never treated as self - only a global-grade caller can use it.
    */
   public User apply(UserRequest request) {
+    requireSelfOrGlobalGrant(
+        (request != null) ? request.getId() : null, PermissionAction.WRITE);
     if (externalUserUrl.isBlank()) {
       Optional<UserEntity> userOptional = Optional.empty();
       if (request != null && request.getId() != null && !request.getId().isBlank()) {
         userOptional = this.userRepository.findByIdAndStatus(request.getId(), UserStatus.active);
       } else if (request != null && request.getEmail() != null && !request.getEmail().isBlank()) {
+        // ofNullable: findByEmailAndStatus answers null for an unknown email, which must surface
+        // as USER_NOT_FOUND below rather than an NPE here.
         userOptional =
-            Optional.of(
+            Optional.ofNullable(
                 this.userRepository.findByEmailAndStatus(
                     normaliseEmail(request.getEmail()), UserStatus.active));
       }
@@ -492,6 +502,7 @@ public class UserService {
    */
   // TODO - determine if the user needs to be removed from ApproverGroups, and anything else
   public void delete(String userId) {
+    requireSelfOrGlobalGrant(userId, PermissionAction.DELETE);
     Optional<UserEntity> user = userRepository.findById(userId);
     Map<String, String> teamRefsAndRoles = relationshipService.roles(userId);
     if (!teamRefsAndRoles.isEmpty()) {
@@ -500,6 +511,38 @@ public class UserService {
     if (user.isPresent()) {
       userRepository.deleteById(userId);
       relationshipService.removeNodeAndEdgeByRefOrSlug(RelationshipType.USER, userId);
+    }
+  }
+
+  /**
+   * Permit self-service, otherwise require a global-scoped {@code user/<action>} grant.
+   *
+   * <p>The route-level {@code @AuthCriteria(resource = USER)} match is scope-blind:
+   * SecurityInterceptor matches the required action against every grant's action strings without
+   * looking at the grant's scope, so a workspace editor/owner's {@code **}/{@code write} grant
+   * satisfies it - yet that grant is authority over the workspace's resources, not over other
+   * users' accounts. Only a global-scoped grant reaches past the caller's own record: the platform
+   * admin/operator roles (the only shapes {@code TokenService.resolvePermissionsForUser} issues at
+   * global scope), an explicitly minted {@code global} token, or the security-off {@code
+   * UnauthenticatedGlobalToken}.
+   */
+  private void requireSelfOrGlobalGrant(String targetUserId, PermissionAction action) {
+    Token identity = identityService.getCurrentIdentity();
+    if (identity != null && targetUserId != null && targetUserId.equals(identity.getPrincipal())) {
+      return;
+    }
+    String requiredRegex =
+        "(\\*{2}|"
+            + PermissionResource.USER.getLabel()
+            + ")\\/(\\*{2}|"
+            + action.getLabel()
+            + ")";
+    if (identity == null
+        || identity.getPermissions().stream()
+            .filter(p -> PermissionScope.global.equals(p.getScope()))
+            .flatMap(p -> p.getActions().stream())
+            .noneMatch(a -> a.matches(requiredRegex))) {
+      throw new BoomerangException(BoomerangError.PERMISSION_DENIED);
     }
   }
 

--- a/service-core/src/main/java/io/boomerang/workflow/ActionService.java
+++ b/service-core/src/main/java/io/boomerang/workflow/ActionService.java
@@ -11,6 +11,8 @@ import io.boomerang.common.model.Workflow;
 import io.boomerang.engine.TaskRunService;
 import io.boomerang.core.RelationshipService;
 import io.boomerang.core.UserService;
+import io.boomerang.core.model.Token;
+import io.boomerang.core.security.IdentityService;
 import io.boomerang.core.entity.UserEntity;
 import io.boomerang.core.enums.RelationshipType;
 import io.boomerang.core.model.User;
@@ -62,6 +64,7 @@ public class ActionService {
   private final WorkflowService workflowService;
   private final RelationshipService relationshipService;
   private final UserService userService;
+  private final IdentityService identityService;
   private final MongoTemplate mongoTemplate;
 
   public ActionService(
@@ -71,6 +74,7 @@ public class ActionService {
       WorkflowService workflowService,
       RelationshipService relationshipService,
       UserService userService,
+      IdentityService identityService,
       MongoTemplate mongoTemplate) {
     this.actionRepository = actionRepository;
     this.approverGroupRepository = approverGroupRepository;
@@ -78,6 +82,7 @@ public class ActionService {
     this.workflowService = workflowService;
     this.relationshipService = relationshipService;
     this.userService = userService;
+    this.identityService = identityService;
     this.mongoTemplate = mongoTemplate;
   }
 
@@ -129,12 +134,16 @@ public class ActionService {
           if (approverGroupEntity.isEmpty()) {
             throw new BoomerangException(BoomerangError.ACTION_INVALID_APPROVERGROUP);
           }
-          // No current user (e.g. security disabled) - mirrors RelationshipService.check()'s
-          // no-principal branch above (already allowed this request through unscoped): there is
-          // no principal-based narrowing possible, so group membership can't be denied on it.
+          // RULED (2026-09-02, maintainer): a group approval is a membership test, and only
+          // named members pass it. A machine token (key/global - resolves no user record) is
+          // denied; an automation that must approve is given a real user identity and placed IN
+          // the group, mirroring GitHub's protection-rule model. Note security-off is NOT this
+          // branch: it resolves the synthetic admin user, which is non-null and simply not a
+          // member. Manual tasks and group-less approvals are deliberately unchanged - they are
+          // completion claims, not accountability controls.
           boolean partOfGroup =
-              userEntity == null
-                  || approverGroupEntity.get().getApprovers().contains(userEntity.getId());
+              userEntity != null
+                  && approverGroupEntity.get().getApprovers().contains(userEntity.getId());
           if (partOfGroup) {
             canBeActioned = true;
           }
@@ -146,9 +155,20 @@ public class ActionService {
       if (canBeActioned) {
         Actioner actioner = new Actioner();
         actioner.setDate(new Date());
-        // No current user (e.g. security disabled) leaves approverId unset rather than NPE-ing -
-        // there is no principal to record as the approver.
-        actioner.setApproverId(userEntity == null ? null : userEntity.getId());
+        // Every decision records SOME actor: the user's id, or - for a machine token on the
+        // still-open manual/group-less paths - the token's own name/principal, so no action ever
+        // lands unattributed (Temporal's capture-approver-metadata norm).
+        if (userEntity != null) {
+          actioner.setApproverId(userEntity.getId());
+        } else {
+          Token machineIdentity = identityService.getCurrentIdentity();
+          actioner.setApproverId(
+              machineIdentity == null
+                  ? null
+                  : (machineIdentity.getName() != null && !machineIdentity.getName().isBlank()
+                      ? machineIdentity.getName()
+                      : machineIdentity.getPrincipal()));
+        }
         actioner.setComments(request.getComments());
         actioner.setApproved(request.isApproved());
         actionEntity.getActioners().add(actioner);

--- a/service-core/src/main/java/io/boomerang/workflow/ActionService.java
+++ b/service-core/src/main/java/io/boomerang/workflow/ActionService.java
@@ -216,6 +216,15 @@ public class ActionService {
     if (actionEntity.isEmpty()) {
       throw new BoomerangException(BoomerangError.ACTION_INVALID_REF);
     }
+    // Same scoping as action(): the caller must reach the Action's Workflow. The refusal is the
+    // same error as not-found, so the response does not disclose whether the id exists.
+    if (!relationshipService.check(
+        RelationshipType.WORKFLOW,
+        actionEntity.get().getWorkflowRef(),
+        Optional.empty(),
+        Optional.empty())) {
+      throw new BoomerangException(BoomerangError.ACTION_INVALID_REF);
+    }
     return this.convertToAction(actionEntity.get());
   }
 

--- a/service-core/src/main/java/io/boomerang/workflow/ActionService.java
+++ b/service-core/src/main/java/io/boomerang/workflow/ActionService.java
@@ -218,6 +218,8 @@ public class ActionService {
     }
     // Same scoping as action(): the caller must reach the Action's Workflow. The refusal is the
     // same error as not-found, so the response does not disclose whether the id exists.
+    // Ruled (2026-09-02): Actions stay OUTSIDE the relationship graph - they scope through
+    // their parent by reference (workflowRef + this one check() hop), never by their own node.
     if (!relationshipService.check(
         RelationshipType.WORKFLOW,
         actionEntity.get().getWorkflowRef(),

--- a/service-core/src/main/java/io/boomerang/workflow/WorkflowRunService.java
+++ b/service-core/src/main/java/io/boomerang/workflow/WorkflowRunService.java
@@ -294,31 +294,15 @@ public class WorkflowRunService {
   public ResponseEntity<WorkflowRun> retry(String team, String workflowRunId) {
     requireWorkspaceRelationship(team, workflowRunId);
 
-    // Ownership is resolved BEFORE the retried run is created, which makes this operation
-    // all-or-nothing. The edge write below is the only step that can fail on an unresolvable
-    // owner, and running it afterwards meant a graph-orphaned run answered the caller with an
-    // unmapped 500 - IllegalArgumentException("Node does not exist: workspace:") out of
-    // RelationshipService.createNodeAndEdge - while the retried run had already been created,
-    // queued and left to execute ownerless.
-    String owner = owningWorkspace(workflowRunId);
+    // Refuse-first: an unresolvable owner fails the request BEFORE the clone is created, keeping
+    // this operation all-or-nothing for a caller. The unscoped retry below records the ownership
+    // edge itself, against this same resolution - never the `team` path segment, which only
+    // proves the caller can reach this run through that path (and for a global-scope token
+    // RelationshipService.check returns true for ANY path workspace), and once recorded wrong
+    // owners permanently.
+    owningWorkspace(workflowRunId);
 
-    WorkflowRun wfRun = retry(workflowRunId, false, 1);
-
-    // Record ownership against the run's REAL owning workspace, resolved from the run - NOT the
-    // `team` path segment. `team` only proves the caller can reach this run through that path, and
-    // for a global-scope token RelationshipService.check returns true for ANY path workspace
-    // (RelationshipService:417-419). Using it here permanently recorded the wrong owner whenever a
-    // run was retried through another workspace's URL.
-    relationshipService.createNodeAndEdge(
-        RelationshipType.WORKSPACE,
-        owner,
-        RelationshipLabel.HAS_WORKFLOWRUN,
-        RelationshipType.WORKFLOWRUN,
-        wfRun.getId(),
-        wfRun.getId(),
-        Optional.empty(),
-        Optional.empty());
-    return ResponseEntity.ok(wfRun);
+    return ResponseEntity.ok(retry(workflowRunId, false, 1));
   }
 
   /**
@@ -395,6 +379,19 @@ public class WorkflowRunService {
    * uses for an unresolvable workspace, rather than minting a run no workspace owns.
    */
   private String owningWorkspace(String workflowRunId) {
+    String workspace = owningWorkspaceOrNull(workflowRunId);
+    if (workspace == null) {
+      throw new BoomerangException(BoomerangError.TEAM_INVALID_REF);
+    }
+    return workspace;
+  }
+
+  /**
+   * The same resolution, answering {@code null} instead of refusing when no workspace owns the
+   * run or its Workflow - for the engine's auto-retry, which must not fail a run's recovery over
+   * graph bookkeeping. A missing run still throws: there is nothing to retry at all.
+   */
+  private String owningWorkspaceOrNull(String workflowRunId) {
     String workspace =
         relationshipService.getParentByLabel(
             RelationshipLabel.HAS_WORKFLOWRUN, RelationshipType.WORKFLOWRUN, workflowRunId);
@@ -412,10 +409,10 @@ public class WorkflowRunService {
     if (workspace == null || workspace.isBlank()) {
       LOGGER.error(
           "[{}] Neither the WorkflowRun nor its Workflow ({}) has an owning workspace in the"
-              + " relationship graph. Refusing the retry rather than creating an ownerless run.",
+              + " relationship graph.",
           workflowRunId,
           workflowRef);
-      throw new BoomerangException(BoomerangError.TEAM_INVALID_REF);
+      return null;
     }
     return workspace;
   }
@@ -901,6 +898,17 @@ public class WorkflowRunService {
     if (workflowRunId == null || workflowRunId.isBlank()) {
       throw new BoomerangException(BoomerangError.WORKFLOWRUN_INVALID_REF);
     }
+    // Ownership travels with creation: user retries and the engine's auto-retry both come through
+    // here, so both record the same owner through this one path. Resolved BEFORE the clone is
+    // created, so resolution can never fail a run that already exists and is queued. Deliberate
+    // asymmetry with retry(team, id): the scoped caller is refused outright on an unresolvable
+    // owner (owningWorkspace throws before delegating here), but the engine's auto-retry must not
+    // fail a run's recovery over graph bookkeeping - it logs and retries ownerless, preserving
+    // the engine path's previous behaviour for the orphan case.
+    String owner = owningWorkspaceOrNull(workflowRunId);
+    if (owner == null) {
+      LOGGER.warn("[{}] Retrying without an owning workspace.", workflowRunId);
+    }
     final Optional<WorkflowRunEntity> optWfRunEntity =
         workflowRunRepository.findById(workflowRunId);
     if (optWfRunEntity.isPresent()) {
@@ -927,6 +935,20 @@ public class WorkflowRunService {
         wfRunEntity.setTrigger(TriggerEnum.retry.getTrigger());
       }
       workflowRunRepository.save(wfRunEntity);
+
+      // Recorded before the clone is queued, so it never executes as reachable-but-unowned
+      // (visible in /query via its Workflow yet denied on GET /{id}).
+      if (owner != null) {
+        relationshipService.createNodeAndEdge(
+            RelationshipType.WORKSPACE,
+            owner,
+            RelationshipLabel.HAS_WORKFLOWRUN,
+            RelationshipType.WORKFLOWRUN,
+            wfRunEntity.getId(),
+            wfRunEntity.getId(),
+            Optional.empty(),
+            Optional.empty());
+      }
 
       workflowExecutionService.queue(wfRunEntity.getId());
 

--- a/service-core/src/main/java/io/boomerang/workflow/WorkflowService.java
+++ b/service-core/src/main/java/io/boomerang/workflow/WorkflowService.java
@@ -357,6 +357,14 @@ public class WorkflowService {
    */
   //  @Audit(scope = PermissionScope.WORKFLOW)
   public Workflow create(String team, Workflow request) {
+    // Validate Access - same guard as TaskService.create: the caller must reach the workspace the
+    // ownership edge below is written into. Guards every create-shaped route: create, apply and
+    // composeApply (when the Workflow does not exist yet) and duplicate all funnel here.
+    if (!relationshipService.check(
+        RelationshipType.WORKSPACE, team, Optional.empty(), Optional.empty())) {
+      throw new BoomerangException(BoomerangError.PERMISSION_DENIED);
+    }
+
     // Ensure name is in slug format
     if (request.getName() != null && !request.getName().isBlank()) {
       request.setName(StringUtil.kebabCase(request.getName()));

--- a/service-core/src/test/java/io/boomerang/core/UserSelfServiceAuthorizationTest.java
+++ b/service-core/src/test/java/io/boomerang/core/UserSelfServiceAuthorizationTest.java
@@ -1,0 +1,231 @@
+package io.boomerang.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.boomerang.common.error.BoomerangException;
+import io.boomerang.core.entity.RoleEntity;
+import io.boomerang.core.entity.UserEntity;
+import io.boomerang.core.enums.RelationshipLabel;
+import io.boomerang.core.enums.RelationshipType;
+import io.boomerang.core.enums.UserStatus;
+import io.boomerang.core.enums.UserType;
+import io.boomerang.core.model.Token;
+import io.boomerang.core.model.UserRequest;
+import io.boomerang.core.repository.RoleRepository;
+import io.boomerang.core.repository.UserRepository;
+import io.boomerang.core.security.enums.AuthScope;
+import io.boomerang.core.security.enums.PermissionScope;
+import io.boomerang.engine.AbstractEngineIntegrationTest;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * The self-vs-admin split on {@code PATCH}/{@code DELETE /api/v2/user/&#123;userId&#125;}.
+ *
+ * <p>The route-level {@code @AuthCriteria(resource = USER)} match is scope-blind:
+ * SecurityInterceptor matches {@code user/write} against EVERY grant's action strings with no
+ * scope filter, and the seeded workspace {@code editor} ({@code **}/{@code write}) and {@code
+ * owner} ({@code **}/{@code **}) roles both satisfy it - so before this guard, any plain member of
+ * any workspace could modify (and an owner delete) ANY user's account. The service now permits
+ * self-service on principal equality and otherwise requires a global-scoped {@code user/<action>}
+ * grant, which {@code TokenService.resolvePermissionsForUser} only issues for the platform
+ * admin/operator roles (workspace grants are workspace-scoped by construction).
+ *
+ * <p>Identities are session tokens with permissions resolved by {@code
+ * TokenService.resolvePermissionsForUser} against real MEMBER_OF edges and the seeded roles - the
+ * production resolution, not synthetic grants.
+ */
+class UserSelfServiceAuthorizationTest extends AbstractEngineIntegrationTest {
+
+  private static final String WORKSPACE = "user-authz-ws";
+  private static final String OWNER_EMAIL = "user-authz-owner@test.local";
+  private static final String TARGET_EMAIL = "user-authz-target@test.local";
+  private static final String ADMIN_EMAIL = "user-authz-admin@test.local";
+
+  @Autowired private UserService userService;
+  @Autowired private UserRepository userRepository;
+  @Autowired private RoleRepository roleRepository;
+  @Autowired private TokenService tokenService;
+
+  private String ownerId;
+  private String targetId;
+  private String adminId;
+
+  @BeforeEach
+  void seedUsersAndRoles() {
+    seedRelationshipRoot();
+    seedWorkspaceRoles();
+    seedGlobalAdminRole();
+    if (!relationshipService.doesSlugOrRefExistForType(RelationshipType.WORKSPACE, WORKSPACE)) {
+      relationshipService.createNode(
+          RelationshipType.WORKSPACE, WORKSPACE, WORKSPACE, Optional.empty());
+    }
+    // Two plain members holding the workspace owner role (**/** - the widest workspace grant),
+    // and one platform admin.
+    ownerId = memberUser(OWNER_EMAIL, "owner");
+    targetId = memberUser(TARGET_EMAIL, "owner");
+    adminId = plainUser(ADMIN_EMAIL, UserType.admin);
+  }
+
+  @Test
+  void aWorkspaceOwnerCannotModifyAnotherUsersAccount() {
+    String nameBefore = userRepository.findById(targetId).orElseThrow().getName();
+    installSessionIdentity(ownerId);
+    UserRequest request = new UserRequest();
+    request.setId(targetId);
+    request.setName("hijacked");
+
+    BoomerangException ex =
+        assertThrows(
+            BoomerangException.class,
+            () -> userService.apply(request),
+            "a workspace grant must not reach another user's account");
+    assertEquals("PERMISSION_DENIED", ex.getReason());
+    assertEquals(
+        nameBefore,
+        userRepository.findById(targetId).orElseThrow().getName(),
+        "the refused update must not touch the target");
+  }
+
+  @Test
+  void aWorkspaceOwnerCannotDeleteAnotherUsersAccount() {
+    installSessionIdentity(ownerId);
+
+    BoomerangException ex =
+        assertThrows(
+            BoomerangException.class,
+            () -> userService.delete(targetId),
+            "a workspace grant must not delete another user's account");
+    assertEquals("PERMISSION_DENIED", ex.getReason());
+    assertTrue(userRepository.findById(targetId).isPresent(), "the target must survive");
+  }
+
+  @Test
+  void aUserCanModifyTheirOwnAccount() {
+    installSessionIdentity(ownerId);
+    UserRequest request = new UserRequest();
+    request.setId(ownerId);
+    request.setDisplayName("Self Service");
+
+    userService.apply(request);
+
+    assertEquals(
+        "Self Service", userRepository.findById(ownerId).orElseThrow().getDisplayName());
+  }
+
+  @Test
+  void aUserCanDeleteTheirOwnAccount() {
+    // Membership-free: delete() refuses any user who still holds workspace roles, so the
+    // self-delete case needs a user with none.
+    String selfId = plainUser("user-authz-self-delete@test.local", UserType.user);
+    installSessionIdentity(selfId);
+
+    userService.delete(selfId);
+
+    assertTrue(userRepository.findById(selfId).isEmpty(), "the self-delete must be served");
+  }
+
+  @Test
+  void anAdminModifiesAndDeletesOtherUsers() {
+    installSessionIdentity(adminId);
+
+    UserRequest request = new UserRequest();
+    request.setId(targetId);
+    request.setName("renamed-by-admin");
+    userService.apply(request);
+    assertEquals("renamed-by-admin", userRepository.findById(targetId).orElseThrow().getName());
+
+    String doomedId = plainUser("user-authz-doomed@test.local", UserType.user);
+    userService.delete(doomedId);
+    assertTrue(userRepository.findById(doomedId).isEmpty(), "the admin delete must be served");
+  }
+
+  /** The maintainer-flagged NPE: update-by-email of a non-existent user must be a mapped error. */
+  @Test
+  void updateByEmailOfANonExistentUserFailsWithUserNotFound() {
+    installSessionIdentity(adminId);
+    UserRequest request = new UserRequest();
+    request.setEmail("user-authz-nobody@test.local");
+    request.setName("nobody");
+
+    BoomerangException ex =
+        assertThrows(
+            BoomerangException.class,
+            () -> userService.apply(request),
+            "a non-existent target must be a mapped domain error, not an NPE");
+    assertEquals("USER_NOT_FOUND", ex.getReason());
+  }
+
+  /** Session identity with permissions resolved exactly as TokenService does per request. */
+  private void installSessionIdentity(String userId) {
+    UserEntity user = userRepository.findById(userId).orElseThrow();
+    Token principal = new Token(AuthScope.session);
+    principal.setPrincipal(userId);
+    principal.setPermissions(tokenService.resolvePermissionsForUser(user));
+    UsernamePasswordAuthenticationToken authentication =
+        new UsernamePasswordAuthenticationToken(userId, null);
+    authentication.setDetails(principal);
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+  }
+
+  // Idempotent per shared database; name defaults to the email so unchanged-assertions can key
+  // on it.
+  private String plainUser(String email, UserType type) {
+    UserEntity user = userRepository.findByEmailAndStatus(email, UserStatus.active);
+    if (user == null) {
+      user = new UserEntity();
+      user.setEmail(email);
+      user.setName(email);
+      user.setType(type);
+      user.setStatus(UserStatus.active);
+      user = userRepository.save(user);
+    }
+    return user.getId();
+  }
+
+  private String memberUser(String email, String role) {
+    UserEntity existing = userRepository.findByEmailAndStatus(email, UserStatus.active);
+    String userId = plainUser(email, UserType.user);
+    if (existing == null) {
+      relationshipService.createNode(RelationshipType.USER, userId, email, Optional.empty());
+      relationshipService.createEdge(
+          RelationshipType.USER,
+          userId,
+          RelationshipLabel.MEMBER_OF,
+          RelationshipType.WORKSPACE,
+          WORKSPACE,
+          Optional.of(Map.of("role", role)));
+    }
+    return userId;
+  }
+
+  /** Mirror of the loader's roles.json workspace/owner document - permission resolution needs it. */
+  private void seedWorkspaceRoles() {
+    if (roleRepository.findByTypeAndName("workspace", "owner") == null) {
+      RoleEntity owner = new RoleEntity();
+      owner.setType(PermissionScope.workspace);
+      owner.setName("owner");
+      owner.setPermissions(List.of("**/**"));
+      roleRepository.save(owner);
+    }
+  }
+
+  /** Mirror of the loader's roles.json global/admin document - admin resolution needs it. */
+  private void seedGlobalAdminRole() {
+    if (roleRepository.findByTypeAndName("global", "admin") == null) {
+      RoleEntity admin = new RoleEntity();
+      admin.setType(PermissionScope.global);
+      admin.setName("admin");
+      admin.setPermissions(List.of("**/**"));
+      roleRepository.save(admin);
+    }
+  }
+}

--- a/service-core/src/test/java/io/boomerang/core/UserServiceTest.java
+++ b/service-core/src/test/java/io/boomerang/core/UserServiceTest.java
@@ -179,6 +179,19 @@ class UserServiceTest {
    */
   @Test
   void applyByMixedCaseEmailQueriesTheLowerCasedValue() {
+    // The update-by-email shape carries no target id, so it is never self: apply requires a
+    // global-scoped user/write grant - the admin this test's javadoc already assumes.
+    io.boomerang.core.model.Token admin =
+        new io.boomerang.core.model.Token(io.boomerang.core.security.enums.AuthScope.session);
+    admin.setPrincipal("admin-id");
+    admin.setPermissions(
+        java.util.List.of(
+            new io.boomerang.core.security.model.ResolvedPermissions(
+                io.boomerang.core.security.enums.PermissionScope.global,
+                "**",
+                java.util.List.of("**/**"))));
+    when(identityService.getCurrentIdentity()).thenReturn(admin);
+
     UserEntity stored = new UserEntity();
     stored.setId("u1");
     stored.setEmail("ada.lovelace@example.com");

--- a/service-core/src/test/java/io/boomerang/workflow/ActionServiceTest.java
+++ b/service-core/src/test/java/io/boomerang/workflow/ActionServiceTest.java
@@ -49,6 +49,7 @@ class ActionServiceTest {
   @Mock private WorkflowService workflowService;
   @Mock private RelationshipService relationshipService;
   @Mock private UserService userService;
+  @Mock private io.boomerang.core.security.IdentityService identityService;
   @Mock private MongoTemplate mongoTemplate;
 
   private ActionService actionService;
@@ -63,6 +64,7 @@ class ActionServiceTest {
             workflowService,
             relationshipService,
             userService,
+            identityService,
             mongoTemplate);
     when(relationshipService.check(any(), anyString(), any(), any())).thenReturn(true);
   }
@@ -96,7 +98,10 @@ class ActionServiceTest {
   }
 
   @Test
-  void approvalWithGroupAndNoCurrentUserIsPermissiveNotNpe() {
+  void approvalWithGroupDeniesACallerWithNoUserRecord() {
+    // A group approval is a membership test - a machine token (resolves no user record) cannot
+    // be a member, so its decision is not recorded. Automations that must approve are given a
+    // real user identity and placed in the group.
     when(userService.getCurrentUser()).thenReturn(null);
     ActionEntity entity = manualAction();
     entity.setType(ActionType.approval);
@@ -114,8 +119,7 @@ class ActionServiceTest {
 
     actionService.action("team1", List.of(request));
 
-    assertThat(entity.getActioners()).hasSize(1);
-    assertThat(entity.getActioners().get(0).getApproverId()).isNull();
+    assertThat(entity.getActioners()).isEmpty();
   }
 
   @Test

--- a/service-core/src/test/java/io/boomerang/workflow/ActionWorkspaceAuthorizationTest.java
+++ b/service-core/src/test/java/io/boomerang/workflow/ActionWorkspaceAuthorizationTest.java
@@ -4,6 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.boomerang.common.entity.ActionEntity;
+import io.boomerang.common.entity.TaskRunEntity;
+import io.boomerang.workspace.repository.ApproverGroupRepository;
+import io.boomerang.core.security.model.ResolvedPermissions;
+import io.boomerang.workflow.model.ActionRequest;
+import io.boomerang.workspace.entity.ApproverGroupEntity;
 import io.boomerang.common.enums.ActionStatus;
 import io.boomerang.common.enums.ActionType;
 import io.boomerang.common.enums.TaskType;
@@ -61,6 +66,7 @@ class ActionWorkspaceAuthorizationTest extends AbstractEngineIntegrationTest {
 
   @Autowired private ActionService actionService;
   @Autowired private ActionRepository actionRepository;
+  @Autowired private ApproverGroupRepository approverGroupRepository;
   @Autowired private WorkflowService workflowService;
   @Autowired private UserRepository userRepository;
   @Autowired private RoleRepository roleRepository;
@@ -75,10 +81,8 @@ class ActionWorkspaceAuthorizationTest extends AbstractEngineIntegrationTest {
   void seedActionInOwningWorkspace() {
     seedRelationshipRoot();
     seedOwnerRole();
-    relationshipService.createNode(
-        RelationshipType.WORKSPACE, OWNING_WORKSPACE, OWNING_WORKSPACE, Optional.empty());
-    relationshipService.createNode(
-        RelationshipType.WORKSPACE, OTHER_WORKSPACE, OTHER_WORKSPACE, Optional.empty());
+    workspaceNode(OWNING_WORKSPACE);
+    workspaceNode(OTHER_WORKSPACE);
     memberId = memberOf(OWNER_EMAIL, OWNING_WORKSPACE);
     outsiderId = memberOf(OUTSIDER_EMAIL, OTHER_WORKSPACE);
 
@@ -101,7 +105,29 @@ class ActionWorkspaceAuthorizationTest extends AbstractEngineIntegrationTest {
     action.setType(ActionType.manual);
     action.setStatus(ActionStatus.submitted);
     action.setCreationDate(new Date());
+    // A quorum-met action ends its backing TaskRun; the ref must resolve or action() refuses.
+    // The unresolvable workflowRunRef sends the async end handler down its graceful cancel path.
+    TaskRunEntity taskRun = new TaskRunEntity();
+    taskRun.setWorkflowRunRef("no-such-workflowrun");
+    action.setTaskRunRef(taskRunRepository.save(taskRun).getId());
     actionId = actionRepository.save(action).getId();
+  }
+
+  // Anchored under root so a global identity (which anchors its walk at ROOT) can resolve these
+  // workspaces - the same shape production has, where every workspace hangs off the root node.
+  private void workspaceNode(String name) {
+    if (relationshipService.doesSlugOrRefExistForType(RelationshipType.WORKSPACE, name)) {
+      return;
+    }
+    relationshipService.createNodeAndEdge(
+        RelationshipType.ROOT,
+        "root",
+        RelationshipLabel.CONTAINS,
+        RelationshipType.WORKSPACE,
+        name,
+        name,
+        Optional.empty(),
+        Optional.empty());
   }
 
   @Test
@@ -125,6 +151,97 @@ class ActionWorkspaceAuthorizationTest extends AbstractEngineIntegrationTest {
 
     Action action = actionService.get(OWNING_WORKSPACE, actionId);
     assertEquals(actionId, action.getId(), "the owning workspace's member must still be served");
+  }
+
+  @Test
+  void aMachineTokenCannotActionAGroupApproval() {
+    ActionEntity action = actionRepository.findById(actionId).orElseThrow();
+    action.setType(ActionType.approval);
+    action.setApproverGroupRef(seedGroupWith(memberId));
+    action.setNumberOfApprovers(1);
+    actionRepository.save(action);
+    installMachineIdentity("ci-bot");
+
+    ActionRequest request = new ActionRequest();
+    request.setId(actionId);
+    request.setApproved(true);
+    actionService.action(OWNING_WORKSPACE, List.of(request));
+
+    ActionEntity after = actionRepository.findById(actionId).orElseThrow();
+    assertEquals(
+        0,
+        after.getActioners() == null ? 0 : after.getActioners().size(),
+        "a machine token is not a group member and must not action a group approval");
+  }
+
+  @Test
+  void aGroupMemberStillActionsTheApproval() {
+    ActionEntity action = actionRepository.findById(actionId).orElseThrow();
+    action.setType(ActionType.approval);
+    action.setApproverGroupRef(seedGroupWith(memberId));
+    action.setNumberOfApprovers(1);
+    actionRepository.save(action);
+    installSessionIdentity(memberId);
+
+    ActionRequest request = new ActionRequest();
+    request.setId(actionId);
+    request.setApproved(true);
+    actionService.action(OWNING_WORKSPACE, List.of(request));
+
+    ActionEntity after = actionRepository.findById(actionId).orElseThrow();
+    assertEquals(1, after.getActioners().size(), "the named group member must still approve");
+    assertEquals(memberId, after.getActioners().get(0).getApproverId());
+  }
+
+  @Test
+  void aMachineTokenActioningAManualTaskIsRecordedByTokenName() {
+    // Manual tasks stay open to machines (a completion claim, not an accountability control) -
+    // but the decision must land attributed to the token, never to nobody.
+    installMachineIdentity("ci-bot");
+
+    ActionRequest request = new ActionRequest();
+    request.setId(actionId);
+    request.setApproved(true);
+    actionService.action(OWNING_WORKSPACE, List.of(request));
+
+    ActionEntity after = actionRepository.findById(actionId).orElseThrow();
+    assertEquals(1, after.getActioners().size());
+    assertEquals(
+        "ci-bot",
+        after.getActioners().get(0).getApproverId(),
+        "a machine actioner must be recorded by its token name, not left unattributed");
+  }
+
+  private String seedGroupWith(String userId) {
+    ApproverGroupEntity group = new ApproverGroupEntity();
+    group.setName("action-authz-group");
+    group.setApprovers(new java.util.LinkedList<>(List.of(userId)));
+    String groupId = approverGroupRepository.save(group).getId();
+    relationshipService.createNodeAndEdge(
+        RelationshipType.WORKSPACE,
+        OWNING_WORKSPACE,
+        RelationshipLabel.HAS_APPROVER_GROUP,
+        RelationshipType.APPROVERGROUP,
+        groupId,
+        groupId,
+        Optional.empty(),
+        Optional.empty());
+    return groupId;
+  }
+
+  /** A minted machine token: global scope, full grant, a name, and NO user record behind it. */
+  private void installMachineIdentity(String tokenName) {
+    Token principal = new Token(AuthScope.global);
+    principal.setPrincipal("machine-" + tokenName);
+    principal.setName(tokenName);
+    principal.setPermissions(
+        List.of(new ResolvedPermissions(PermissionScope.global, "machine", List.of("**/**"))));
+    org.springframework.security.authentication.UsernamePasswordAuthenticationToken authentication =
+        new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+            "machine-" + tokenName, null);
+    authentication.setDetails(principal);
+    org.springframework.security.core.context.SecurityContextHolder.getContext()
+        .setAuthentication(authentication);
   }
 
   /** Session identity with permissions resolved exactly as TokenService does per request. */

--- a/service-core/src/test/java/io/boomerang/workflow/ActionWorkspaceAuthorizationTest.java
+++ b/service-core/src/test/java/io/boomerang/workflow/ActionWorkspaceAuthorizationTest.java
@@ -1,0 +1,208 @@
+package io.boomerang.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.boomerang.common.entity.ActionEntity;
+import io.boomerang.common.enums.ActionStatus;
+import io.boomerang.common.enums.ActionType;
+import io.boomerang.common.enums.TaskType;
+import io.boomerang.common.error.BoomerangException;
+import io.boomerang.common.model.Task;
+import io.boomerang.common.model.Workflow;
+import io.boomerang.common.model.WorkflowTask;
+import io.boomerang.common.model.WorkflowTaskDependency;
+import io.boomerang.core.TokenService;
+import io.boomerang.core.entity.RoleEntity;
+import io.boomerang.core.entity.UserEntity;
+import io.boomerang.core.enums.RelationshipLabel;
+import io.boomerang.core.enums.RelationshipType;
+import io.boomerang.core.enums.UserStatus;
+import io.boomerang.core.enums.UserType;
+import io.boomerang.core.model.Token;
+import io.boomerang.core.repository.RoleRepository;
+import io.boomerang.core.repository.UserRepository;
+import io.boomerang.core.security.enums.AuthScope;
+import io.boomerang.core.security.enums.PermissionScope;
+import io.boomerang.engine.AbstractEngineIntegrationTest;
+import io.boomerang.engine.repository.ActionRepository;
+import io.boomerang.workflow.model.Action;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * The workspace guard on {@code GET /api/v2/workspace/&#123;workspace&#125;/action/&#123;id&#125;}.
+ *
+ * <p>{@link ActionService#action} already refuses an Action whose Workflow the caller cannot reach,
+ * and {@code query}/{@code summary} narrow through {@code RelationshipService.filter} - but {@code
+ * get} read straight from the repository, so any authenticated caller could read any workspace's
+ * approval (its comments, actioners and instructions) by id. The guard is the same {@code
+ * check(WORKFLOW, workflowRef)} the mutation path uses, refusing with the same {@code
+ * ACTION_INVALID_REF} it answers for a missing id, so the response does not disclose whether the
+ * Action exists.
+ *
+ * <p>Identities are session tokens with permissions resolved by {@code
+ * TokenService.resolvePermissionsForUser} against a real MEMBER_OF edge and the seeded {@code
+ * workspace/owner} role - the production resolution, not synthetic grants.
+ */
+class ActionWorkspaceAuthorizationTest extends AbstractEngineIntegrationTest {
+
+  private static final String OWNING_WORKSPACE = "action-authz-owning-ws";
+  private static final String OTHER_WORKSPACE = "action-authz-other-ws";
+  private static final String OWNER_EMAIL = "action-authz-owner@test.local";
+  private static final String OUTSIDER_EMAIL = "action-authz-outsider@test.local";
+
+  @Autowired private ActionService actionService;
+  @Autowired private ActionRepository actionRepository;
+  @Autowired private WorkflowService workflowService;
+  @Autowired private UserRepository userRepository;
+  @Autowired private RoleRepository roleRepository;
+  @Autowired private TokenService tokenService;
+
+  private String memberId;
+  private String outsiderId;
+  private String actionId;
+
+  /** Seeds under the base class's global identity; each test installs its own member identity. */
+  @BeforeEach
+  void seedActionInOwningWorkspace() {
+    seedRelationshipRoot();
+    seedOwnerRole();
+    relationshipService.createNode(
+        RelationshipType.WORKSPACE, OWNING_WORKSPACE, OWNING_WORKSPACE, Optional.empty());
+    relationshipService.createNode(
+        RelationshipType.WORKSPACE, OTHER_WORKSPACE, OTHER_WORKSPACE, Optional.empty());
+    memberId = memberOf(OWNER_EMAIL, OWNING_WORKSPACE);
+    outsiderId = memberOf(OUTSIDER_EMAIL, OTHER_WORKSPACE);
+
+    // Unique per test: @BeforeEach runs per test method against one shared database, and the
+    // unscoped create paths do not enforce name uniqueness.
+    String workflowId =
+        createLinearWorkflow("action-authz-" + java.util.UUID.randomUUID().toString().substring(0, 8));
+    relationshipService.createNodeAndEdge(
+        RelationshipType.WORKSPACE,
+        OWNING_WORKSPACE,
+        RelationshipLabel.HAS_WORKFLOW,
+        RelationshipType.WORKFLOW,
+        workflowId,
+        workflowId,
+        Optional.empty(),
+        Optional.empty());
+
+    ActionEntity action = new ActionEntity();
+    action.setWorkflowRef(workflowId);
+    action.setType(ActionType.manual);
+    action.setStatus(ActionStatus.submitted);
+    action.setCreationDate(new Date());
+    actionId = actionRepository.save(action).getId();
+  }
+
+  @Test
+  void aMemberOfAnotherWorkspaceCannotReadTheActionById() {
+    installSessionIdentity(outsiderId);
+
+    BoomerangException ex =
+        assertThrows(
+            BoomerangException.class,
+            () -> actionService.get(OTHER_WORKSPACE, actionId),
+            "an Action must not be readable by a caller who cannot reach its Workflow");
+    assertEquals(
+        "ACTION_INVALID_REF",
+        ex.getReason(),
+        "the refusal must be the same error as not-found, disclosing nothing");
+  }
+
+  @Test
+  void aMemberOfTheOwningWorkspaceStillReadsTheAction() {
+    installSessionIdentity(memberId);
+
+    Action action = actionService.get(OWNING_WORKSPACE, actionId);
+    assertEquals(actionId, action.getId(), "the owning workspace's member must still be served");
+  }
+
+  /** Session identity with permissions resolved exactly as TokenService does per request. */
+  private void installSessionIdentity(String userId) {
+    UserEntity user = userRepository.findById(userId).orElseThrow();
+    Token principal = new Token(AuthScope.session);
+    principal.setPrincipal(userId);
+    principal.setPermissions(tokenService.resolvePermissionsForUser(user));
+    UsernamePasswordAuthenticationToken authentication =
+        new UsernamePasswordAuthenticationToken(userId, null);
+    authentication.setDetails(principal);
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+  }
+
+  // A real user with a MEMBER_OF edge carrying the owner role - what WorkspaceService.create
+  // records for a member. Idempotent: @BeforeEach runs per test against one shared database.
+  private String memberOf(String email, String workspace) {
+    UserEntity user = userRepository.findByEmailAndStatus(email, UserStatus.active);
+    if (user == null) {
+      user = new UserEntity();
+      user.setEmail(email);
+      user.setName(email);
+      user.setType(UserType.user);
+      user.setStatus(UserStatus.active);
+      user = userRepository.save(user);
+      relationshipService.createNode(
+          RelationshipType.USER, user.getId(), email, Optional.empty());
+      relationshipService.createEdge(
+          RelationshipType.USER,
+          user.getId(),
+          RelationshipLabel.MEMBER_OF,
+          RelationshipType.WORKSPACE,
+          workspace,
+          Optional.of(Map.of("role", "owner")));
+    }
+    return user.getId();
+  }
+
+  /** Mirror of the loader's roles.json workspace/owner document - permission resolution needs it. */
+  private void seedOwnerRole() {
+    if (roleRepository.findByTypeAndName("workspace", "owner") == null) {
+      RoleEntity owner = new RoleEntity();
+      owner.setType(PermissionScope.workspace);
+      owner.setName("owner");
+      owner.setPermissions(List.of("**/**"));
+      roleRepository.save(owner);
+    }
+  }
+
+  private String createLinearWorkflow(String name) {
+    Task template = new Task();
+    template.setName(name + "-echo");
+    template.setType(TaskType.template);
+    template.getSpec().setImage("busybox:latest");
+    template.getSpec().setCommand(List.of("echo"));
+    String templateId = taskService.create(template).getId();
+
+    Workflow workflow = new Workflow();
+    workflow.setName(name);
+    workflow.setTasks(
+        List.of(
+            workflowTask("start", TaskType.start, null),
+            workflowTask("a", TaskType.template, templateId, "start"),
+            workflowTask("end", TaskType.end, null, "a")));
+    return workflowService.create(workflow, false).getBody().getId();
+  }
+
+  private static WorkflowTask workflowTask(
+      String name, TaskType type, String taskRef, String... dependsOn) {
+    WorkflowTask task = new WorkflowTask();
+    task.setName(name);
+    task.setType(type);
+    task.setTaskRef(taskRef);
+    for (String dep : dependsOn) {
+      WorkflowTaskDependency dependency = new WorkflowTaskDependency();
+      dependency.setTaskRef(dep);
+      task.getDependencies().add(dependency);
+    }
+    return task;
+  }
+}

--- a/service-core/src/test/java/io/boomerang/workflow/WorkflowCreateAuthorizationTest.java
+++ b/service-core/src/test/java/io/boomerang/workflow/WorkflowCreateAuthorizationTest.java
@@ -1,0 +1,179 @@
+package io.boomerang.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.boomerang.common.entity.WorkflowEntity;
+import io.boomerang.common.error.BoomerangException;
+import io.boomerang.common.model.Workflow;
+import io.boomerang.core.TokenService;
+import io.boomerang.core.entity.RoleEntity;
+import io.boomerang.core.entity.UserEntity;
+import io.boomerang.core.enums.RelationshipLabel;
+import io.boomerang.core.enums.RelationshipType;
+import io.boomerang.core.enums.UserStatus;
+import io.boomerang.core.enums.UserType;
+import io.boomerang.core.model.Token;
+import io.boomerang.core.repository.RoleRepository;
+import io.boomerang.core.repository.UserRepository;
+import io.boomerang.core.security.enums.AuthScope;
+import io.boomerang.core.security.enums.PermissionScope;
+import io.boomerang.engine.AbstractEngineIntegrationTest;
+import io.boomerang.workflow.repository.WorkflowRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * The workspace guard on {@code POST /api/v2/workspace/&#123;workspace&#125;/workflow}.
+ *
+ * <p>{@code WorkflowService.create(team, ...)} wrote the {@code HAS_WORKFLOW} ownership edge into
+ * whatever workspace the path named without ever asking whether the caller can reach that
+ * workspace - the sibling {@code TaskService.create(team, ...)} checks {@code check(WORKSPACE,
+ * team)} first. Every create-shaped entry point funnels here: {@code apply} (when the named
+ * Workflow does not exist yet), {@code composeApply} via {@code apply}, and {@code duplicate}, so
+ * one guard at the top of {@code create} covers all four routes.
+ *
+ * <p>Identities are session tokens with permissions resolved by {@code
+ * TokenService.resolvePermissionsForUser} against a real MEMBER_OF edge and the seeded {@code
+ * workspace/owner} role - the production resolution, not synthetic grants.
+ */
+class WorkflowCreateAuthorizationTest extends AbstractEngineIntegrationTest {
+
+  private static final String MY_WORKSPACE = "wf-create-authz-my-ws";
+  private static final String FOREIGN_WORKSPACE = "wf-create-authz-foreign-ws";
+  private static final String MEMBER_EMAIL = "wf-create-authz-member@test.local";
+  private static final String TASK_SLUG = "wf-create-authz-task";
+
+  @Autowired private WorkflowService workflowService;
+  @Autowired private WorkflowRepository workflowRepository;
+  @Autowired private UserRepository userRepository;
+  @Autowired private RoleRepository roleRepository;
+  @Autowired private TokenService tokenService;
+
+  private String memberId;
+
+  /** Seeds under the base class's global identity, then installs the session member. */
+  @BeforeEach
+  void establishWorkspaceMember() {
+    seedRelationshipRoot();
+    seedTeamQuotaSettings();
+    seedTaskSettings();
+    setFeatureSetting("workspaceQuotas", false);
+    setFeatureSetting("globalParameters", false);
+    setFeatureSetting("workspaceParameters", false);
+    seedGlobalTask(TASK_SLUG);
+    seedOwnerRole();
+    workspaceNode(MY_WORKSPACE);
+    workspaceNode(FOREIGN_WORKSPACE);
+
+    UserEntity member = userRepository.findByEmailAndStatus(MEMBER_EMAIL, UserStatus.active);
+    if (member == null) {
+      member = new UserEntity();
+      member.setEmail(MEMBER_EMAIL);
+      member.setName(MEMBER_EMAIL);
+      member.setType(UserType.user);
+      member.setStatus(UserStatus.active);
+      member = userRepository.save(member);
+      relationshipService.createNode(
+          RelationshipType.USER, member.getId(), MEMBER_EMAIL, Optional.empty());
+      relationshipService.createEdge(
+          RelationshipType.USER,
+          member.getId(),
+          RelationshipLabel.MEMBER_OF,
+          RelationshipType.WORKSPACE,
+          MY_WORKSPACE,
+          Optional.of(Map.of("role", "owner")));
+    }
+    memberId = member.getId();
+
+    Token principal = new Token(AuthScope.session);
+    principal.setPrincipal(memberId);
+    principal.setPermissions(tokenService.resolvePermissionsForUser(member));
+    UsernamePasswordAuthenticationToken authentication =
+        new UsernamePasswordAuthenticationToken(memberId, null);
+    authentication.setDetails(principal);
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+  }
+
+  @Test
+  void creatingIntoAWorkspaceTheCallerCannotReachIsRefusedBeforeAnythingIsWritten() {
+    String name = "wf-create-authz-intruder";
+
+    BoomerangException ex =
+        assertThrows(
+            BoomerangException.class,
+            () -> workflowService.create(FOREIGN_WORKSPACE, runnableWorkflow(name, TASK_SLUG)),
+            "creating into an unreachable workspace must be refused");
+    assertEquals("PERMISSION_DENIED", ex.getReason());
+
+    assertFalse(
+        relationshipService.doesSlugOrRefExistForType(RelationshipType.WORKFLOW, name),
+        "a refused create must not write the ownership node/edge");
+    assertTrue(
+        workflowRepository.findAll().stream()
+            .map(WorkflowEntity::getName)
+            .noneMatch(name::equals),
+        "a refused create must not persist the Workflow entity");
+  }
+
+  @Test
+  void aMemberCreatesIntoTheirOwnWorkspaceAndOwnershipIsRecorded() {
+    String name = "wf-create-authz-mine";
+
+    Workflow created = workflowService.create(MY_WORKSPACE, runnableWorkflow(name, TASK_SLUG));
+
+    assertEquals(name, created.getName(), "the member's create must be served");
+    assertEquals(
+        MY_WORKSPACE,
+        relationshipService.getParentByLabel(
+            RelationshipLabel.HAS_WORKFLOW, RelationshipType.WORKFLOW, workflowRef(name)),
+        "the created Workflow must be owned by the named workspace");
+  }
+
+  private String workflowRef(String name) {
+    return relationshipService
+        .filter(
+            RelationshipType.WORKFLOW,
+            Optional.of(List.of(name)),
+            Optional.of(RelationshipType.WORKSPACE),
+            Optional.of(List.of(MY_WORKSPACE)),
+            false)
+        .get(0);
+  }
+
+  // Anchored under root so a global (ROOT-anchored) identity can resolve these workspaces - the
+  // same shape production has, where every workspace hangs off the root node.
+  private void workspaceNode(String name) {
+    if (relationshipService.doesSlugOrRefExistForType(RelationshipType.WORKSPACE, name)) {
+      return;
+    }
+    relationshipService.createNodeAndEdge(
+        RelationshipType.ROOT,
+        "root",
+        RelationshipLabel.CONTAINS,
+        RelationshipType.WORKSPACE,
+        name,
+        name,
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  /** Mirror of the loader's roles.json workspace/owner document - permission resolution needs it. */
+  private void seedOwnerRole() {
+    if (roleRepository.findByTypeAndName("workspace", "owner") == null) {
+      RoleEntity owner = new RoleEntity();
+      owner.setType(PermissionScope.workspace);
+      owner.setName("owner");
+      owner.setPermissions(List.of("**/**"));
+      roleRepository.save(owner);
+    }
+  }
+}

--- a/service-core/src/test/java/io/boomerang/workflow/WorkflowRunRetryOwnerTest.java
+++ b/service-core/src/test/java/io/boomerang/workflow/WorkflowRunRetryOwnerTest.java
@@ -160,6 +160,76 @@ class WorkflowRunRetryOwnerTest extends AbstractEngineIntegrationTest {
         "the retry must fail before the clone is created, leaving only the source run");
   }
 
+  /**
+   * The engine's auto-retry calls the unscoped {@code retry(workflowRunId, start, retryCount)}
+   * directly (WorkflowExecutionService), which used to create the clone WITHOUT a HAS_WORKFLOWRUN
+   * edge - the run appeared in {@code /query} (filter walks the Workflow) but {@code GET
+   * /&#123;id&#125;} was denied (check anchors on the run). Ownership is now written by the
+   * unscoped method itself, so user retries and engine auto-retries produce identically-owned
+   * runs through one path.
+   */
+  @Test
+  void anUnscopedRetryRecordsTheSameOwnerAsAUserRetry() {
+    seedRelationshipRoot();
+    relationshipService.createNode(
+        RelationshipType.WORKSPACE, OWNING_WORKSPACE, OWNING_WORKSPACE, Optional.empty());
+
+    String workflowId = createLinearWorkflow("retry-owner-engine");
+    relationshipService.createNodeAndEdge(
+        RelationshipType.WORKSPACE,
+        OWNING_WORKSPACE,
+        RelationshipLabel.HAS_WORKFLOW,
+        RelationshipType.WORKFLOW,
+        workflowId,
+        workflowId,
+        Optional.empty(),
+        Optional.empty());
+    String wfRunId =
+        workflowService.submit(workflowId, new WorkflowSubmitRequest(), false).getId();
+    relationshipService.createNodeAndEdge(
+        RelationshipType.WORKSPACE,
+        OWNING_WORKSPACE,
+        RelationshipLabel.HAS_WORKFLOWRUN,
+        RelationshipType.WORKFLOWRUN,
+        wfRunId,
+        wfRunId,
+        Optional.empty(),
+        Optional.empty());
+
+    // The engine path: no workspace segment, no scoped wrapper.
+    WorkflowRun retried = workflowRunService.retry(wfRunId, false, 1);
+
+    assertEquals(
+        OWNING_WORKSPACE,
+        relationshipService.getParentByLabel(
+            RelationshipLabel.HAS_WORKFLOWRUN, RelationshipType.WORKFLOWRUN, retried.getId()),
+        "an engine auto-retry must record the same owner a user retry records");
+  }
+
+  /**
+   * The deliberate asymmetry with the scoped path: a user retry of an unowned run refuses
+   * (TEAM_INVALID_REF, nothing created - the test above this one), but the engine's auto-retry
+   * must never fail a run's recovery over graph bookkeeping, so an unresolvable owner logs and
+   * creates the clone ownerless - exactly what the engine path produced before for EVERY retry.
+   */
+  @Test
+  void anUnscopedRetryOfAnUnownedRunStillRetriesAndStaysOwnerless() {
+    seedRelationshipRoot();
+
+    // Graph-orphaned: no HAS_WORKFLOW edge and no HAS_WORKFLOWRUN edge.
+    String workflowId = createLinearWorkflow("retry-owner-engine-orphan");
+    String wfRunId =
+        workflowService.submit(workflowId, new WorkflowSubmitRequest(), false).getId();
+
+    WorkflowRun retried = workflowRunService.retry(wfRunId, false, 1);
+
+    assertEquals(
+        "",
+        relationshipService.getParentByLabel(
+            RelationshipLabel.HAS_WORKFLOWRUN, RelationshipType.WORKFLOWRUN, retried.getId()),
+        "the orphan engine retry stays ownerless rather than failing or inventing an owner");
+  }
+
   private String createLinearWorkflow(String name) {
     Task template = new Task();
     template.setName(name + "-echo");

--- a/specifications/v5-enhancemnet.md
+++ b/specifications/v5-enhancemnet.md
@@ -580,6 +580,20 @@ evidence (file/class or measurement).
   fix cleaned up). The one condition that reopens this: direct per-action grants (assigning an
   approval to a user outside the workspace, external sharing of a single gate) — that cannot
   be expressed as a parent hop.
+- **RULED (2026-09-02, maintainer): machine tokens cannot action GROUP approvals; every
+  actioned decision records an actor.** A group approval is a membership test, and only named
+  members pass it — `ActionService.action` denies a caller that resolves no user record
+  (minted key/global tokens; security-off is NOT this branch, it resolves the synthetic admin
+  user, which is simply not a member). An automation that must approve is given a real user
+  identity and placed IN the group — GitHub's environment-protection-rule model (named
+  users/teams only; machines only as installed Apps). Manual tasks and group-less approvals
+  stay open to machines — they are completion claims, not accountability controls — but the
+  `Actioner.approverId` then carries the token's name (falling back to its principal), the
+  Temporal capture-approver-metadata norm, so no decision ever lands unattributed. Alternatives
+  rejected: B (a `machineActionable` per-gate flag — configuration surface for a case the
+  group-membership model already expresses) and C (deny machines everywhere — breaks the
+  legitimate CI-completes-a-manual-gate flow). Pinned by
+  `ActionWorkspaceAuthorizationTest` and `ActionServiceTest.approvalWithGroupDeniesACallerWithNoUserRecord`.
 - **Q-133** Does the CHEER model sharpen or blur the engine-mode seam (where relationships don't exist and workspace resolves to `default`)?
   - ✅ **Answered (2026-07-22): sharpens it.** Access-as-anchored-reachability means
     `engine` mode simply doesn't load (or no-ops) the relationship layer and anchors at the

--- a/specifications/v5-enhancemnet.md
+++ b/specifications/v5-enhancemnet.md
@@ -569,6 +569,17 @@ evidence (file/class or measurement).
     Modulith interface (the `RelationshipService` API), not internals — `core` must not
     become a god-module; and the mode-loading matrix (Q-205/Q-206) needs sub-`core`
     granularity so `engine` mode can exclude or no-op the relationship layer.
+- **RULED (2026-09-02, maintainer): Actions and TaskRuns stay OUTSIDE the relationship graph.**
+  The graph holds durable organisational structure only — workspaces, users, workflows,
+  approver groups, and WORKFLOWRUN as the tenancy anchor. Everything beneath a run (TaskRuns,
+  Actions) scopes through its parent by reference (`workflowRunRef`/`workflowRef` + one
+  `check()` hop), never by its own node. Rationale: scoping is already complete via the parent
+  hop; these are engine-created execution artefacts on the hot path, so per-object nodes would
+  add graph writes for no authz gain; and the entity's ref is the single source of truth — a
+  parallel edge is a second copy that can drift (the exact class of bug the retry edge-owner
+  fix cleaned up). The one condition that reopens this: direct per-action grants (assigning an
+  approval to a user outside the workspace, external sharing of a single gate) — that cannot
+  be expressed as a parent hop.
 - **Q-133** Does the CHEER model sharpen or blur the engine-mode seam (where relationships don't exist and workspace resolves to `default`)?
   - ✅ **Answered (2026-07-22): sharpens it.** Access-as-anchored-reachability means
     `engine` mode simply doesn't load (or no-ops) the relationship layer and anchors at the


### PR DESCRIPTION
Implements the five AuthZ rulings (2026-09-02) now that relationship enforcement is live (#321), plus the group-approval machine-token ruling.

## Fixes

| # | Ruling | Commit |
|---|--------|--------|
| 1 | `ActionService.get` scopes the Action through its Workflow (`check(WORKFLOW, workflowRef)`), refusing with the same `ACTION_INVALID_REF` as not-found — no existence oracle | 66c3c68 |
| 2 | `WorkflowService.create` checks workspace reachability (`check(WORKSPACE, team)`) before writing the entity or its `HAS_WORKFLOW` ownership edge — covers create/apply/composeApply/duplicate via the single write site | 10aef82 |
| 4 | Every retry records its owning workspace through the one unscoped create path — the retry edge-owner bug (path team recorded instead of the run's owner) is gone | c4febf2 |
| 5 | `PATCH`/`DELETE /user/{userId}` is self-service or global-SCOPED grant only — closes the workspace editor/owner (`**/write`, `**/**`) hole | 68e0ebc |
| A | **Group approvals are a membership test**: a machine token (resolves no user record) is denied; automations that must approve get a real user identity placed in the group (GitHub protection-rule model). Manual tasks and group-less approvals stay open to machines, but `Actioner.approverId` now records the token's name — no decision lands unattributed (Temporal norm) | 9fef7f3 |

Ruling 3 (merge `WorkspaceActionService`+`ActionService`) was already done in F3 — nothing to ship.

## Rulings recorded in the spec

- Actions and TaskRuns stay OUTSIDE the relationship graph (parent-hop scoping; reopens only for direct per-action grants).
- The machine-token/group-approval model above.

## Verification

`mvn -pl service-core -am clean test`: **321 passed / 0 failed / 2 skipped** (baseline 306). New pins: `ActionWorkspaceAuthorizationTest` (5), `WorkflowCreateWorkspaceAuthorizationTest`, retry edge-owner tests, `UserSelfServiceAuthorizationTest`; `ActionServiceTest.approvalWithGroupDeniesACallerWithNoUserRecord` inverts the unit test that pinned the old bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
