### PR TITLE
chore: two issue forms + CONTRIBUTING for the monorepo tracker

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -1,0 +1,50 @@
+name: "🐛 Bug"
+description: Something is not working as expected.
+type: Bug
+labels: [needs-triage]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened, and what did you expect?
+      description: A short, human description in your own words. Screenshots are welcome.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How to reproduce
+      description: >
+        Steps, or an exported workflow JSON that shows it. Mention how you run Flow if it matters
+        (standalone or engine mode; Tekton or kube-jobs dispatcher; docker-compose). Issues without a way
+        to reproduce get `needs-info` and are closed after 14 days.
+      placeholder: |
+        1. Create a workflow with …
+        2. Run it with …
+        3. See …
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: The Flow version you are running (Settings → About, or the image tag).
+      placeholder: 5.0.0-beta.2
+    validations:
+      required: true
+  - type: dropdown
+    id: where
+    attributes:
+      label: Where does this happen?
+      options:
+        - Web UI
+        - API & engine
+        - Task execution (dispatcher)
+        - Install & upgrade (loader, compose, charts)
+        - Not sure
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant log lines or an error response. Redact tokens and secrets.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/2-feature.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature.yml
@@ -1,0 +1,25 @@
+name: "✨ Feature"
+description: Suggest a change or something new.
+type: Feature
+labels: [needs-triage]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to do? Describe the situation, not the solution.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: If you have one. Alternatives you considered are useful too.
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: A bullet list of what would make this done. It helps maintainers and agents scope the work.
+      placeholder: |
+        - [ ] …
+        - [ ] …

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Ask a question / get help
+    url: https://join.slack.com/t/boomerang-io/shared_invite/zt-pxo2yw2o-c3~6YvWkKNrKIwhIBAKhaw
+    about: Questions and support happen on the Boomerang Slack, not in the issue tracker.
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/boomerang-io/flow/security/advisories/new
+    about: Please use private vulnerability reporting rather than a public issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to Boomerang Flow
+
+Thanks for helping. This is the canonical contributing guide for the Boomerang projects; the copy in
+[`boomerang-io/.github`](https://github.com/boomerang-io/.github) mirrors it.
+
+## Issues
+
+- **Bug** or **Feature** — open one with the matching form; the form sets the issue type and adds
+  `needs-triage`. A maintainer sets the component (`frontend` / `backend`) and priority during triage.
+- **Questions and support** — [Slack](https://join.slack.com/t/boomerang-io/shared_invite/zt-pxo2yw2o-c3~6YvWkKNrKIwhIBAKhaw),
+  not the issue tracker.
+- **Security** — [private vulnerability reporting](https://github.com/boomerang-io/flow/security/advisories/new),
+  never a public issue.
+
+Bugs without a way to reproduce them get `needs-info` and are closed after 14 days; reopen any time with the
+missing detail.
+
+## Pull requests
+
+Link the PR to an issue (`Fixes #123`). Fork-and-PR or a branch in the repository both work. Keep the commit
+subject to 72 characters and use a conventional-commit prefix (`feat:`, `fix:`, `docs:`, …) so release notes can
+be generated. Building and running the product locally is described in the [README](README.md); the design
+records that explain *why* things are the way they are live in [`specifications/`](specifications/).
+
+## AI assistance
+
+Use whatever tools you like, but the words in an issue or PR must be your own and you must be able to explain
+the change: we do not accept issues or pull requests that the author cannot discuss without an AI.
+
+## Versioning
+
+One product tag builds the whole compatible image set (plain semver on the 5.x line). See the README's
+"Packaging and releases".


### PR DESCRIPTION
Step 0 of the issue-tracker consolidation (labels, forms, `community` sunset).

- `.github/ISSUE_TEMPLATE/1-bug.yml` — Bug form: `type: Bug`, 5 fields / 3 required (what happened, how to reproduce, version), a "Where does this happen?" dropdown, logs. Applies `needs-triage`.
- `.github/ISSUE_TEMPLATE/2-feature.yml` — Feature form: `type: Feature`, 3 fields / 1 required, optional acceptance criteria.
- `.github/ISSUE_TEMPLATE/config.yml` — blank issues off for non-maintainers; questions go to Slack; vulnerabilities go to private reporting (enabled on the repo today).
- `CONTRIBUTING.md` — canonical copy; the org `.github` repo will mirror it.

Having any file in this repository's `ISSUE_TEMPLATE/` opts it out of the org-level 2020 markdown templates. Labels (`frontend`, `backend`, `needs-triage`, `needs-info`, `claude`) and Issue Types on the 13 open issues were applied directly on the repo.
