### PR TITLE
test: pin Tekton category round-trip (community#227)

### DIFF
--- a/service-core/src/test/java/io/boomerang/workflow/tekton/TektonConverterCategoryRoundTripTest.java
+++ b/service-core/src/test/java/io/boomerang/workflow/tekton/TektonConverterCategoryRoundTripTest.java
@@ -1,0 +1,54 @@
+package io.boomerang.workflow.tekton;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.boomerang.common.model.Task;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A Task's category MUST survive the Tekton YAML round-trip: it rides in the
+ * {@code boomerang.io/category} annotation on the way out and is lifted back onto the typed
+ * field (and removed from the annotation map) on the way in. A Tekton task with no such
+ * annotation yields no category rather than an error.
+ */
+class TektonConverterCategoryRoundTripTest {
+
+  @Test
+  void categorySurvivesTheTektonRoundTrip() {
+    Task task = new Task();
+    task.setName("servicenow-create-incident");
+    task.setCategory("ServiceNow");
+    task.getSpec().setImage("ubuntu");
+
+    TektonTask tektonTask = TektonConverter.convertTaskTemplateToTektonTask(task);
+    assertThat(tektonTask.getMetadata().getAnnotations())
+        .containsEntry("boomerang.io/category", "ServiceNow");
+
+    Task restored = TektonConverter.convertTektonTaskToTaskTemplate(tektonTask);
+
+    assertThat(restored.getCategory()).isEqualTo("ServiceNow");
+    assertThat(tektonTask.getMetadata().getAnnotations()).doesNotContainKey("boomerang.io/category");
+    assertThat(restored.getAnnotations()).doesNotContainKey("boomerang.io/category");
+  }
+
+  @Test
+  void aTektonTaskWithoutTheCategoryAnnotationYieldsNoCategory() {
+    TektonTask tektonTask = new TektonTask();
+    TektonMetadata metadata = new TektonMetadata();
+    metadata.setName("plain-task");
+    metadata.getAnnotations().put("description", "no category here");
+    tektonTask.setMetadata(metadata);
+    TektonSpec spec = new TektonSpec();
+    Step step = new Step();
+    step.setName("plain-task");
+    step.setImage("ubuntu");
+    spec.setSteps(List.of(step));
+    tektonTask.setSpec(spec);
+
+    assertThatCode(() -> TektonConverter.convertTektonTaskToTaskTemplate(tektonTask))
+        .doesNotThrowAnyException();
+    assertThat(TektonConverter.convertTektonTaskToTaskTemplate(tektonTask).getCategory()).isNull();
+  }
+}


### PR DESCRIPTION
## Summary

Regression coverage written to close two 2021 community issues as verified-fixed. Only one of the two could be pinned.

- **boomerang-io/community#227** "Saving Task in YAML view loses the Category" — **verified fixed.** `TektonConverterCategoryRoundTripTest` asserts that `category="ServiceNow"` survives `convertTaskTemplateToTektonTask` → `convertTektonTaskToTaskTemplate` (written to the `boomerang.io/category` annotation at `TektonConverter.java:48`, lifted back onto the typed field and removed from the annotation map at `:109-113`), and that a Tekton task without the annotation yields a null category rather than throwing.
- **boomerang-io/community#205** "Empty Event Body causing exception" — **NOT fixed on `feat-v5`; deliberately not committed.** A CloudEvent built with `CloudEventBuilder.v1().withoutData()` still NPEs: `CloudEventUtils.mapData` returns `null` when the event carries no data, and `WebhookEventService.eventToRunParams` dereferences it (`WebhookEventService.java:219`, reached via `processEvent` at `:90`). The failing test is held back so this branch stays green; the fix is a null guard on `data` in `eventToRunParams`.

## Test plan

- [x] `mvn -o -pl service-core -am test -Dtest='TektonConverter*'` — 6 tests, 0 failures (the 2 new plus the 4 existing `TektonConverterTests`).
