### PR TITLE
docs: community health files for the monorepo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Closes #
 
 #### Testing / reviewing
 
-{{ how a reviewer can verify this — commands, screens, or the test that pins it }}
+{{ how a reviewer can verify this — commands, screens, or the test steps }}
 
 #### AI assistance
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+Closes #
+
+{{ one-paragraph description of the change and why }}
+
+#### Changelog
+
+- {{ new / changed / removed }}
+
+#### Testing / reviewing
+
+{{ how a reviewer can verify this — commands, screens, or the test that pins it }}
+
+#### AI assistance
+
+{{ none, or which tool and for what — see CONTRIBUTING.md }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+The Boomerang projects follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+
+To report a concern, contact a [maintainer](MAINTAINERS.md) directly on the Boomerang Slack or by email; reports are handled confidentially.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,21 @@
+# Maintainers
+
+The project maintainers, in alphabetical order by GitHub handle. Maintainers review and merge pull requests,
+triage issues, and cut releases.
+
+| Name            | GitHub                                       | Organization |
+| --------------- | -------------------------------------------- | ------------ |
+| Adrienne Hudson | [@amhudson](https://github.com/amhudson)     | Independent  |
+| —               | [@gchickma](https://github.com/gchickma)     | IBM          |
+| Marcus Roy      | [@marcusdroy](https://github.com/marcusdroy) | Independent  |
+| Tim Bula        | [@timrbula](https://github.com/timrbula)     | IBM Research |
+| Tyson Lawrie    | [@tlawrie](https://github.com/tlawrie)       | Flowabl      |
+
+## Emeritus
+
+Thank you to the maintainers who have moved on.
+
+| Name          | GitHub                                             |
+| ------------- | -------------------------------------------------- |
+| Benjamin Ruby | [@BenjaminRuby](https://github.com/BenjaminRuby)   |
+| Costel Moraru | [@morarucostel](https://github.com/morarucostel)   |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,7 +9,7 @@ triage issues, and cut releases.
 | —               | [@gchickma](https://github.com/gchickma)     | IBM          |
 | Marcus Roy      | [@marcusdroy](https://github.com/marcusdroy) | Independent  |
 | Tim Bula        | [@timrbula](https://github.com/timrbula)     | IBM Research |
-| Tyson Lawrie    | [@tlawrie](https://github.com/tlawrie)       | Flowabl      |
+| Tyson Lawrie    | [@tlawrie](https://github.com/tlawrie)       | Cheer.dev      |
 
 ## Emeritus
 

--- a/README.md
+++ b/README.md
@@ -169,3 +169,11 @@ The following classes are conditionally loaded based on this flag
 | SecurityConfiguration                                      | true      |
 | SecurityDisabledConfiguration                              | false     |
 
+## Community and contributing
+
+- Bugs and features: [open an issue](https://github.com/boomerang-io/flow/issues/new/choose) — see [CONTRIBUTING.md](CONTRIBUTING.md).
+- Questions: the [Boomerang Slack](https://join.slack.com/t/boomerang-io/shared_invite/zt-pxo2yw2o-c3~6YvWkKNrKIwhIBAKhaw) — see [SUPPORT.md](SUPPORT.md).
+- Security: [SECURITY.md](SECURITY.md). Maintainers: [MAINTAINERS.md](MAINTAINERS.md). Roadmap: [ROADMAP.md](ROADMAP.md).
+
+The former central tracker, [`boomerang-io/community`](https://github.com/boomerang-io/community), is archived; its
+open issues were triaged into this repository on 2026-09-01 and its old URLs redirect.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,13 @@
+# Roadmap
+
+Boomerang Flow's roadmap lives in two places:
+
+- **What is planned and in flight** — the [Boomerang Flow project board](https://github.com/orgs/boomerang-io/projects/4/views/1)
+  and the open [Feature issues](https://github.com/boomerang-io/flow/issues?q=is%3Aissue%20is%3Aopen%20type%3AFeature).
+- **Why v5 looks the way it does** — the v5 master specification,
+  [`specifications/v5-enhancemnet.md`](specifications/v5-enhancemnet.md) (the filename typo is historical), and the
+  decision records around it in [`specifications/`](specifications/).
+
+Earlier roadmaps (2022–2023) are preserved in the archived
+[`boomerang-io/community`](https://github.com/boomerang-io/community/blob/main/ROADMAP.md) repository; every
+item from them that is still wanted exists as an issue here.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+| ------- | --------- |
+| 5.x     | Yes       |
+| 4.x and earlier | No — please upgrade |
+
+## Reporting a vulnerability
+
+Use GitHub's private vulnerability reporting: <https://github.com/boomerang-io/flow/security/advisories/new>.
+Do not open a public issue for a security problem.
+
+You will get an acknowledgement within 5 working days. We aim to publish a fix and an advisory within 90 days
+of a confirmed report (sooner for actively exploited issues) and will credit you in the advisory unless you ask
+otherwise.
+
+## Scope
+
+The `boomerang-io/flow` monorepo (service-core, service-dispatcher, service-loader, client-web) and the images
+built from it. Container-image CVEs are tracked by the SBOM pipeline (`.github/workflows/sbom.yml`).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,9 @@
+# Support
+
+- **Questions and help**: the Boomerang Slack — <https://join.slack.com/t/boomerang-io/shared_invite/zt-pxo2yw2o-c3~6YvWkKNrKIwhIBAKhaw>
+- **Bugs and feature requests**: <https://github.com/boomerang-io/flow/issues/new/choose> (use the forms)
+- **Security vulnerabilities**: see [SECURITY.md](SECURITY.md) — never a public issue
+- **Documentation**: <https://www.useboomerang.io/docs>
+
+The issue tracker is for actionable bugs and features; support conversations happen on Slack so that the
+tracker stays small and triaged.


### PR DESCRIPTION
Step 4a of the issue-tracker consolidation: the community-health files, canonical in this repo (`boomerang-io/.github` mirrors them in a companion PR).

- `CODE_OF_CONDUCT.md` (CNCF), `SECURITY.md` (5.x supported; private vulnerability reporting), `SUPPORT.md` (Slack), `MAINTAINERS.md` (refreshed), `ROADMAP.md` (points at the project board and the v5 spec), `.github/PULL_REQUEST_TEMPLATE.md`.
- README gains a "Community and contributing" section; the `community` repo is archived after this.
