### PR TITLE
fix(event): accept CloudEvents with no data instead of throwing (#381)

### DIFF
--- a/service-core/src/main/java/io/boomerang/event/WebhookEventService.java
+++ b/service-core/src/main/java/io/boomerang/event/WebhookEventService.java
@@ -223,8 +223,11 @@ public class WebhookEventService {
             event,
             PojoCloudEventDataMapper.from(
                 JACKSON2_MAPPER, new TypeReference<Map<String, Object>>() {}));
-    params.add(new RunParam("data", (Object) data, ParamType.object));
-    params.addAll(ParameterUtil.mapToRunParamList(data.getValue()));
+    // A CloudEvent may carry no data at all - the run then gets only the event param.
+    if (data != null) {
+      params.add(new RunParam("data", (Object) data, ParamType.object));
+      params.addAll(ParameterUtil.mapToRunParamList(data.getValue()));
+    }
     return params;
   }
 }

--- a/service-core/src/test/java/io/boomerang/event/WebhookEventEmptyDataTest.java
+++ b/service-core/src/test/java/io/boomerang/event/WebhookEventEmptyDataTest.java
@@ -1,0 +1,95 @@
+package io.boomerang.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.boomerang.common.enums.TriggerEnum;
+import io.boomerang.common.model.RunParam;
+import io.boomerang.common.model.WorkflowRun;
+import io.boomerang.common.model.WorkflowSubmitRequest;
+import io.boomerang.core.RelationshipService;
+import io.boomerang.core.enums.RelationshipLabel;
+import io.boomerang.core.enums.RelationshipType;
+import io.boomerang.workflow.WorkflowRunService;
+import io.boomerang.workflow.WorkflowService;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import java.net.URI;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * A CloudEvent is allowed to carry no data at all. The listener once dereferenced the data
+ * unconditionally and threw on an empty body; a data-less event MUST still reach
+ * {@code WorkflowService.submit} with the event itself as the only run param.
+ */
+@ExtendWith(MockitoExtension.class)
+class WebhookEventEmptyDataTest {
+
+  private static final String WORKFLOW_REF = "workflow-1";
+  private static final String WORKSPACE_REF = "workspace-1";
+
+  @Mock private WorkflowService workflowService;
+  @Mock private WorkflowRunService workflowRunService;
+  @Mock private RelationshipService relationshipService;
+
+  private WebhookEventService webhookEventService;
+
+  @BeforeEach
+  void setUp() {
+    webhookEventService =
+        new WebhookEventService(
+            workflowService,
+            workflowRunService,
+            Optional.empty(),
+            Optional.empty(),
+            relationshipService);
+    when(relationshipService.check(
+            RelationshipType.WORKFLOW, WORKFLOW_REF, Optional.empty(), Optional.empty()))
+        .thenReturn(true);
+    when(relationshipService.getParentByLabel(
+            RelationshipLabel.HAS_WORKFLOW, RelationshipType.WORKFLOW, WORKFLOW_REF))
+        .thenReturn(WORKSPACE_REF);
+  }
+
+  @Test
+  void anEventWithoutDataIsSubmittedWithOnlyTheEventParam() {
+    CloudEvent event =
+        CloudEventBuilder.v1()
+            .withId(UUID.randomUUID().toString())
+            .withSource(URI.create("urn:webhook-empty-data-test"))
+            .withType("io.boomerang.test.webhook")
+            .withSubject(WORKFLOW_REF + "/topic")
+            .withoutData()
+            .build();
+    WorkflowRun expected = new WorkflowRun();
+    expected.setId("run-1");
+    when(workflowService.submit(
+            eq(WORKSPACE_REF), eq(WORKFLOW_REF), any(WorkflowSubmitRequest.class), anyBoolean()))
+        .thenReturn(expected);
+
+    assertThatCode(() -> webhookEventService.processEvent(event, Optional.of(WORKFLOW_REF)))
+        .doesNotThrowAnyException();
+
+    ArgumentCaptor<WorkflowSubmitRequest> request =
+        ArgumentCaptor.forClass(WorkflowSubmitRequest.class);
+    verify(workflowService)
+        .submit(eq(WORKSPACE_REF), eq(WORKFLOW_REF), request.capture(), anyBoolean());
+    assertThat(request.getValue().getTrigger()).isEqualTo(TriggerEnum.event);
+    assertThat(request.getValue().getParams())
+        .extracting(RunParam::getName)
+        .contains("event")
+        .doesNotContain("data");
+  }
+}

--- a/specifications/api-contract.md
+++ b/specifications/api-contract.md
@@ -95,6 +95,9 @@ Accepted CloudEvent shape (structured mode):
   "data": { "event": "request_success", "inputs": { "key": "value" } } }
 ```
 
+`data` is optional: an event without it is accepted and its run params carry only `event`
+(`WebhookEventService.java:226-230`).
+
 A caller with no relationship to the workflow gets `PERMISSION_DENIED`
 (`WebhookEventService.java:94-97`); a rejected request creates no run.
 


### PR DESCRIPTION
## Bug

`POST /api/v2/event` with a CloudEvent that carries no `data` threw before any run was submitted:

```
NullPointerException: Cannot invoke "io.cloudevents.core.data.PojoCloudEventData.getValue()" because "data" is null
```

`WebhookEventService.eventToRunParams` called `CloudEventUtils.mapData(...)`, which returns `null` for a data-less event, and then dereferenced the result unconditionally.

## Fix

`service-core/src/main/java/io/boomerang/event/WebhookEventService.java:226-230` — the `data` run param and its expanded entries are added only when the mapped data is non-null; the `event` param is always present. This mirrors how `processWFE` already treats an absent payload (`:198-201`). No other behaviour changes.

`specifications/api-contract.md` gains one sentence recording that `data` is optional on `POST /api/v2/event`.

## Test

`service-core/src/test/java/io/boomerang/event/WebhookEventEmptyDataTest.java` builds a CloudEvent with `withoutData()`, calls `processEvent`, and asserts that no exception is thrown, that `WorkflowService.submit` receives a `TriggerEnum.event` request, and that its params contain `event` and no `data`. It failed with the NPE above before the change.

```
mvn -o -pl service-core -am test -Dtest='WebhookEvent*' -DfailIfNoTests=false
Tests run: 2, Failures: 0, Errors: 0 -- io.boomerang.event.WebhookEventAuthorizationTest
Tests run: 1, Failures: 0, Errors: 0 -- io.boomerang.event.WebhookEventEmptyDataTest
```

Fixes #381