### PR TITLE
fix(task): omit unset Step fields from task YAML/JSON output

### DIFF
--- a/service-core/src/main/java/io/boomerang/workflow/tekton/Step.java
+++ b/service-core/src/main/java/io/boomerang/workflow/tekton/Step.java
@@ -1,8 +1,10 @@
 package io.boomerang.workflow.tekton;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.boomerang.common.model.TaskEnvVar;
+import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Step {
 
   private String name;

--- a/service-core/src/main/java/io/boomerang/workflow/tekton/TektonMetadata.java
+++ b/service-core/src/main/java/io/boomerang/workflow/tekton/TektonMetadata.java
@@ -1,10 +1,12 @@
 package io.boomerang.workflow.tekton;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Data;
 
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TektonMetadata {
   private String name;
   private Map<String, String> labels = new HashMap<String, String>();

--- a/service-core/src/main/java/io/boomerang/workflow/tekton/TektonSpec.java
+++ b/service-core/src/main/java/io/boomerang/workflow/tekton/TektonSpec.java
@@ -1,5 +1,6 @@
 package io.boomerang.workflow.tekton;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.boomerang.common.model.ParamSpec;
 import io.boomerang.common.model.ResultSpec;
 import java.time.Duration;
@@ -7,6 +8,7 @@ import java.util.List;
 import lombok.Data;
 
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TektonSpec {
 
   private String description;

--- a/service-core/src/test/java/io/boomerang/workflow/tekton/TektonConverterTests.java
+++ b/service-core/src/test/java/io/boomerang/workflow/tekton/TektonConverterTests.java
@@ -1,9 +1,12 @@
 package io.boomerang.workflow.tekton;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.dataformat.yaml.YAMLWriteFeature;
 import io.boomerang.common.model.ParamSpec;
 import io.boomerang.common.model.Task;
 import java.io.IOException;
@@ -80,6 +83,37 @@ class TektonConverterTests {
     assertEquals("Task", exported.getKind());
     assertEquals("example-task-name", exported.getMetadata().getName());
     assertEquals("Worker", exported.getMetadata().getAnnotations().get("boomerang.io/category"));
+  }
+
+  @Test
+  void testYamlExportOmitsUnsetStepFields() {
+    Step step = new Step();
+    step.setName("run");
+    step.setImage("alpine:3");
+    step.setScript("#!/bin/sh\necho one\necho two\n");
+
+    TektonSpec spec = new TektonSpec();
+    spec.setSteps(List.of(step));
+    TektonMetadata metadata = new TektonMetadata();
+    metadata.setName("script-only");
+    TektonTask task = new TektonTask();
+    task.setApiVersion("tekton.dev/v1beta1");
+    task.setKind("Task");
+    task.setMetadata(metadata);
+    task.setSpec(spec);
+
+    // Same write features as YamlJacksonHttpMessageConverter, the mapper behind Accept: x-yaml.
+    YAMLMapper mapper =
+        YAMLMapper.builder()
+            .enable(YAMLWriteFeature.LITERAL_BLOCK_STYLE)
+            .enable(YAMLWriteFeature.MINIMIZE_QUOTES)
+            .disable(YAMLWriteFeature.WRITE_DOC_START_MARKER)
+            .build();
+    String yaml = mapper.writeValueAsString(task);
+
+    assertFalse(yaml.contains(": null"), yaml);
+    assertTrue(yaml.contains("script: |"), yaml);
+    assertTrue(yaml.contains("image: alpine:3"), yaml);
   }
 
   private TektonTask loadTektonTask(String file) throws IOException {


### PR DESCRIPTION
`GET /api/v2/task/{name}` with `Accept: application/x-yaml` emits `null` for every unset `Step` field. `TektonTask` already carries `@JsonInclude(NON_NULL)`, but `Step`, `TektonSpec` and `TektonMetadata` did not, so the YAML converter (`service-core/src/main/java/io/boomerang/workflow/config/YamlJacksonHttpMessageConverter.java`) wrote the nulls verbatim. The same nulls appeared in the JSON representation.

## Before

```yaml
spec:
  steps:
  - name: run
    image: alpine:3
    script: |
      #!/bin/sh
      echo one
      echo two
    workingDir: null
    env: null
    command: null
    args: null
```

## After

```yaml
spec:
  steps:
  - name: run
    image: alpine:3
    script: |
      #!/bin/sh
      echo one
      echo two
```

## Change

- `@JsonInclude(JsonInclude.Include.NON_NULL)` on `Step`, `TektonSpec`, `TektonMetadata` (`service-core/src/main/java/io/boomerang/workflow/tekton/`). `TektonTask` was already annotated.
- `TektonConverterTests.testYamlExportOmitsUnsetStepFields` serialises a step with only `name`, `image` and a multi-line `script` through a mapper built with the converter's write features and asserts no `: null` while `script: |` is kept.

Import is unaffected: the annotation only governs serialisation, so absent keys still deserialise as `null` (`testYamlImport*`, `TektonConverterCategoryRoundTripTest` pass unchanged).

## Verification

`mvn -o -pl service-core -am test -Dtest='TektonConverter*,YamlConfiguration*,*Task*'` — 0 failures (`TektonConverterTests` 5/5, `YamlConfigurationTest` 2/2, `TektonConverterCategoryRoundTripTest` 2/2).
