### PR TITLE
chore: drop spec-file citations from the authentication code comments (#395)

### DIFF
--- a/client-web/src/Config/serverFetch.ts
+++ b/client-web/src/Config/serverFetch.ts
@@ -24,10 +24,10 @@ import axios, { type AxiosInstance } from "axios";
 const INTERNAL_API_ORIGIN = process.env.CORE_SERVICE_INTERNAL_ORIGIN ?? "";
 
 /*
- * specifications/authentication.md: `POST /api/v2/auth/exchange` mints an httpOnly, Secure,
- * SameSite=Lax session cookie carrying an opaque `bfs_<uuid>`, which `AuthenticationFilter`
- * reads. VERIFIED end-to-end (2026-08-27, secured compose stack): an SSR fetch of /home carrying
- * only the session Cookie header returns the authenticated render.
+ * `POST /api/v2/auth/exchange` mints an httpOnly, Secure, SameSite=Lax session cookie carrying
+ * an opaque `bfs_<uuid>`, which `AuthenticationFilter` reads. Verified end-to-end against a
+ * secured compose stack: an SSR fetch of /home carrying only the session Cookie header returns
+ * the authenticated render.
  * The browser's axios instance relies on `withCredentials: true` (see servicesConfig.ts) to send
  * cookies automatically; that browser cookie jar doesn't exist in Node, so the incoming request's
  * `Cookie` header is read off the *inbound* SSR `Request` and forwarded explicitly on the

--- a/client-web/src/Config/servicesConfig.ts
+++ b/client-web/src/Config/servicesConfig.ts
@@ -57,7 +57,7 @@ type QueryArg = {
 };
 
 export const serviceUrl = {
-  // Sign-in flow (specifications/authentication.md). getAuthConfig is unauthenticated - the
+  // Sign-in flow. getAuthConfig is unauthenticated - the
   // signed-out page reads it to decide which sign-in surface (if any) to offer. postAuthExchange
   // mints the httpOnly bfs_ session cookie (empty body = proxy-forwarded identity; {idToken,
   // nonce} = direct OIDC login). postAuthLogout revokes the session and clears the cookie.

--- a/client-web/src/Features/Auth/Auth.action.node.spec.ts
+++ b/client-web/src/Features/Auth/Auth.action.node.spec.ts
@@ -1,8 +1,8 @@
 // @vitest-environment node
 //
-// The server-side OIDC sign-in flow (specifications/authentication.md - maintainer ruling
-// 2026-08-31: the PKCE dance moved off the browser into route action/loader halves on the SSR
-// server, remix-auth v4 + remix-auth-oauth2 v3 underneath). These run in a REAL Node environment
+// The server-side OIDC sign-in flow (the PKCE dance runs in route action/loader halves on the
+// SSR server, not in the browser, with remix-auth v4 + remix-auth-oauth2 v3 underneath). These
+// run in a REAL Node environment
 // because that is where the flow now executes: the browser only ever sees the authorize redirect
 // and the final Set-Cookie relay - the id_token and code_verifier never leave this process.
 //

--- a/client-web/src/Features/Auth/Session.action.node.spec.ts
+++ b/client-web/src/Features/Auth/Session.action.node.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 //
-// The session-side SSR actions (specifications/authentication.md - BFF slice, 2026-09-01): the
+// The session-side SSR actions: the
 // browser no longer calls POST /api/v2/auth/exchange or POST /api/v2/auth/logout itself. Both
 // moved into route actions on the SSR server (session.server.ts), because both hinge on the same
 // mechanic the sign-in flow already proved (oidc.server.ts): the Java response's Set-Cookie

--- a/client-web/src/Features/Auth/oidc.server.ts
+++ b/client-web/src/Features/Auth/oidc.server.ts
@@ -1,5 +1,5 @@
 /*
- * Server-side OIDC sign-in (specifications/authentication.md, maintainer ruling 2026-08-31): the
+ * Server-side OIDC sign-in: the
  * PKCE dance runs here in route action/loader halves via remix-auth v4 + remix-auth-oauth2 v3
  * (Arctic underneath) - the browser only ever sees the authorize redirect and the final
  * Set-Cookie relay, so the id_token and code_verifier never reach it. Java stays the verifier

--- a/client-web/src/Features/Auth/session.server.ts
+++ b/client-web/src/Features/Auth/session.server.ts
@@ -1,5 +1,5 @@
 /*
- * Session lifecycle actions (specifications/authentication.md - BFF slice, 2026-09-01): the
+ * Session lifecycle actions: the
  * browser no longer POSTs /api/v2/auth/exchange or /api/v2/auth/logout itself. Both were
  * browser-side precisely because their responses' Set-Cookie must reach the browser - and the
  * server-side sign-in flow (oidc.server.ts) already proved the alternative mechanic: run the

--- a/service-core/src/main/java/io/boomerang/core/AuthControllerV2.java
+++ b/service-core/src/main/java/io/boomerang/core/AuthControllerV2.java
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /*
- * The unified token exchange (specifications/authentication.md §1/§2/§5): a single endpoint, two
+ * The unified token exchange (see specifications/authorization.md): a single endpoint, two
  * identity sources (an authenticating proxy's already-resolved principal, or a direct OIDC
  * id_token), converging on the same session-minting path. Delivered as an httpOnly, Secure,
  * SameSite=Lax cookie carrying only the opaque bfs_<uuid> value - never permissions, which stay

--- a/service-core/src/main/java/io/boomerang/core/TokenService.java
+++ b/service-core/src/main/java/io/boomerang/core/TokenService.java
@@ -607,7 +607,7 @@ public class TokenService {
   /**
    * Same resolve-or-create-user + mint flow as {@link #createSessionToken}, but also returns the
    * raw {@code bfs_<uuid>} value - needed by {@code POST /api/v2/auth/exchange} to set the
-   * httpOnly session cookie (specifications/authentication.md §1). The entity only ever persists
+   * httpOnly session cookie. The entity only ever persists
    * the SHA-256 hash (see {@link #mintSessionToken}), so the raw value only ever exists on the
    * stack of the request that minted it.
    */

--- a/service-core/src/main/java/io/boomerang/core/model/AuthExchangeRequest.java
+++ b/service-core/src/main/java/io/boomerang/core/model/AuthExchangeRequest.java
@@ -3,7 +3,7 @@ package io.boomerang.core.model;
 import lombok.Data;
 
 /**
- * The body of {@code POST /api/v2/auth/exchange} (specifications/authentication.md §1). Both
+ * The body of {@code POST /api/v2/auth/exchange}. Both
  * fields are optional and empty is a valid, meaningful request: an empty body selects the
  * proxy-forwarded-identity path. A populated {@code idToken} selects the direct OIDC login path -
  * {@code nonce} must be the value the frontend generated for its PKCE authorize request, so it can

--- a/service-core/src/main/java/io/boomerang/core/security/AuthExchangeService.java
+++ b/service-core/src/main/java/io/boomerang/core/security/AuthExchangeService.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Service;
 
 /**
  * The two identity sources of {@code POST /api/v2/auth/exchange} converging on the same
- * session-minting path (specifications/authentication.md §1). Standalone-only: the exchange
+ * session-minting path. Standalone-only: the exchange
  * endpoint has no meaning for an embedded engine.
  */
 @Service

--- a/service-core/src/main/java/io/boomerang/core/security/AuthenticationFilter.java
+++ b/service-core/src/main/java/io/boomerang/core/security/AuthenticationFilter.java
@@ -60,7 +60,7 @@ public class AuthenticationFilter extends OncePerRequestFilter {
   //  private static final String X_SLACK_TIMESTAMP = "X-Slack-Request-Timestamp";
   private static final String PATH_ACTIVATE = "/api/v2/activate";
   private static final String PATH_PROFILE = "/api/v2/profile";
-  // The unified token exchange (specifications/authentication.md §1) is now, alongside
+  // The unified token exchange (PATH_AUTH_EXCHANGE) is now, alongside
   // PATH_PROFILE/PATH_ACTIVATE, a valid first call for a brand-new proxy-identified caller - so it
   // gets the same allowActivation/allowUserCreation treatment below. It is ALSO the one path this
   // filter must not reject with a 401 when it resolves no identity at all: the direct OIDC login
@@ -142,8 +142,8 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 
   /*
    * Extracts the opaque bfs_ value from the session cookie (SessionCookie.NAME), if present - the
-   * additional identity source minted by POST /api/v2/auth/exchange (specifications/authentication.md
-   * §1), added alongside the existing branches above, never in place of them.
+   * additional identity source minted by POST /api/v2/auth/exchange, added alongside the existing
+   * branches above, never in place of them.
    */
   private String getSessionCookieValue(HttpServletRequest request) {
     Cookie[] cookies = request.getCookies();

--- a/service-core/src/main/java/io/boomerang/core/security/EngineWorkspaceInterceptor.java
+++ b/service-core/src/main/java/io/boomerang/core/security/EngineWorkspaceInterceptor.java
@@ -11,7 +11,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
 
 /*
- * Engine-mode workspace guard (AM-10, specifications/merge-execution-plan.md): in engine mode the
+ * Engine-mode workspace guard: in engine mode the
  * `system` workspace IS the workspace - "engine basically runs in what the admins use". It is
  * seeded by changeunit _0014__SeedSystemWorkspace (unlimited-quota, undeletable) and `system` is
  * in WorkspaceService.RESERVED_WORKSPACE_NAMES, so no user workspace can ever shadow it.

--- a/service-core/src/main/java/io/boomerang/core/security/EngineWorkspaceInterceptorConfiguration.java
+++ b/service-core/src/main/java/io/boomerang/core/security/EngineWorkspaceInterceptorConfiguration.java
@@ -6,11 +6,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-// AM-10: engine mode only - the system workspace IS the workspace in engine mode, so every
+// Engine mode only - the system workspace IS the workspace in engine mode, so every
 // workspace-scoped request must target it. Registered on the workspace-scoped v2 paths that
-// survive in engine mode (see the mode matrix - WorkspaceControllerV2 itself, and its bare
-// /api/v2/workspace collection paths, is STANDALONE-only and never loads here). H14-a retired the
-// deprecated /api/v2/team/{team} alias entirely, so only /api/v2/workspace/{workspace} remains.
+// survive in engine mode (see the mode matrix in specifications/architecture.md -
+// WorkspaceControllerV2 itself, and its bare /api/v2/workspace collection paths, is
+// STANDALONE-only and never loads here). The deprecated /api/v2/team/{team} alias is gone, so
+// only /api/v2/workspace/{workspace} remains.
 @Configuration
 @ConditionalOnFlowMode(FlowMode.ENGINE)
 public class EngineWorkspaceInterceptorConfiguration implements WebMvcConfigurer {

--- a/service-core/src/main/java/io/boomerang/core/security/FlowAuthenticationException.java
+++ b/service-core/src/main/java/io/boomerang/core/security/FlowAuthenticationException.java
@@ -7,8 +7,8 @@ import org.springframework.security.core.AuthenticationException;
  * Carries a {@link BoomerangError} through Spring Security's {@link AuthenticationException}
  * machinery so the delegated entry point (see {@link DelegatedAuthenticationEntryPoint}) can
  * render the platform's standard {@code RestErrorResponse} body - code, reason, message - instead
- * of the framework default, and so the response distinguishes WHY authentication failed (§5,
- * specifications/authentication.md) rather than a bare 401.
+ * of the framework default, and so the response distinguishes WHY authentication failed rather
+ * than a bare 401.
  */
 public class FlowAuthenticationException extends AuthenticationException {
 

--- a/service-core/src/main/java/io/boomerang/core/security/OidcTokenVerifier.java
+++ b/service-core/src/main/java/io/boomerang/core/security/OidcTokenVerifier.java
@@ -31,8 +31,8 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 /**
- * Verifies id_tokens for the direct OIDC login path of {@code POST /api/v2/auth/exchange}
- * (specifications/authentication.md §1/§5): fetches the configured issuer's JWKS (via standard
+ * Verifies id_tokens for the direct OIDC login path of {@code POST /api/v2/auth/exchange}:
+ * fetches the configured issuer's JWKS (via standard
  * OIDC discovery), verifies the JWS signature, and checks {@code iss}, {@code aud}, {@code exp}
  * and {@code nonce} - the reference implementation this design is modelled on base64-decodes and
  * trusts transport instead; this endpoint is reachable directly by a browser, so it earns trust

--- a/service-core/src/main/java/io/boomerang/core/security/SecurityConfiguration.java
+++ b/service-core/src/main/java/io/boomerang/core/security/SecurityConfiguration.java
@@ -34,7 +34,7 @@ public class SecurityConfiguration {
   // AuthenticationFilter below, since that filter runs ahead of this authorization decision.
   static final String GITHUB_CALLBACK = "/api/v2/integration/github/callback";
 
-  // The unified token exchange's direct OIDC login path (specifications/authentication.md §1) is
+  // The unified token exchange's direct OIDC login path is
   // reached by the browser with no prior credential - AuthenticationFilter still RUNS for this
   // path (so proxy-forwarded identity is picked up when present), it just no longer 401s when it
   // resolves nothing; permitAll here is what lets that unauthenticated request continue to the

--- a/service-core/src/main/java/io/boomerang/core/security/SessionCookie.java
+++ b/service-core/src/main/java/io/boomerang/core/security/SessionCookie.java
@@ -6,8 +6,8 @@ import org.springframework.http.ResponseCookie;
 /**
  * The single definition of the session cookie's name and attributes - minted by {@code POST
  * /api/v2/auth/exchange}, cleared by {@code POST /api/v2/auth/logout}, read by {@link
- * AuthenticationFilter}. httpOnly, {@code Secure}, {@code SameSite=Lax} (follows ARCHIE's model,
- * specifications/authentication.md §1); carries only the opaque {@code bfs_<uuid>} value -
+ * AuthenticationFilter}. httpOnly, {@code Secure}, {@code SameSite=Lax} (follows ARCHIE's
+ * model); carries only the opaque {@code bfs_<uuid>} value -
  * permissions are never embedded, they stay server-side on the persisted {@code TokenEntity} that
  * value hashes to, which is what makes this structurally immune to the 5KB cookie overflow the
  * embedded-permissions reference implementation hit.

--- a/service-core/src/main/java/io/boomerang/core/security/UnauthenticatedGlobalToken.java
+++ b/service-core/src/main/java/io/boomerang/core/security/UnauthenticatedGlobalToken.java
@@ -76,7 +76,7 @@ public class UnauthenticatedGlobalToken extends Token {
    * an admin-typed profile adds no privilege; it only makes the profile/context surface tell the
    * UI the truth about the power the caller already has. Never seeded or written to Mongo: a
    * stored user could be surfaced in member lists of secured instances and, worse, activated by
-   * an IDP email match. Ruled 2026-08-26 - see specifications/authentication.md.
+   * an IDP email match. See specifications/authorization.md (security-off identity).
    */
   public static UserEntity virtualUser() {
     UserEntity user = new UserEntity();

--- a/service-core/src/main/java/io/boomerang/core/security/enums/AuthScope.java
+++ b/service-core/src/main/java/io/boomerang/core/security/enums/AuthScope.java
@@ -6,11 +6,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 /*
- * T6-3: the TOKEN CLASS (actor/ceiling-typed, not resource-scope-typed) - who/what a token
+ * The TOKEN CLASS (actor/ceiling-typed, not resource-scope-typed) - who/what a token
  * represents and the ceiling of what it can ever be granted. This is deliberately NOT the same
- * concept as a permission grant's scope (see {@link PermissionScope}) - see this track's ruling
- * (specifications/merge-execution-plan.md, T6-3) for why the two were split out of what used to be
- * a single overloaded enum.
+ * concept as a permission grant's scope (see {@link PermissionScope}); the two were split out of
+ * what used to be a single overloaded enum (see specifications/authorization.md).
  *
  * <ul>
  *   <li>{@code session} - human, short-lived, permissions re-resolved on login/exchange.

--- a/service-core/src/main/java/io/boomerang/core/security/enums/PermissionScope.java
+++ b/service-core/src/main/java/io/boomerang/core/security/enums/PermissionScope.java
@@ -6,11 +6,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 /*
- * T6-3: a permission GRANT's scope (what a {@link io.boomerang.core.security.model.
+ * A permission GRANT's scope (what a {@link io.boomerang.core.security.model.
  * ResolvedPermissions} entry is anchored to) - split out of the former overloaded {@link
  * AuthScope}, which conflated this with the token's own class. Named after ARCHIE's {@code
- * PermissionScope} (the maintainer's preferred name where the split has no churn reason to keep
- * the old name - see this track's ruling, specifications/merge-execution-plan.md T6-3).
+ * PermissionScope} (see specifications/authorization.md).
  *
  * <p>Only two values exist because only two ever have: every {@code ResolvedPermissions} the
  * codebase builds is either anchored to a single workspace ({@code principal}=workspaceId) or

--- a/service-core/src/main/java/io/boomerang/workflow/WorkflowService.java
+++ b/service-core/src/main/java/io/boomerang/workflow/WorkflowService.java
@@ -110,7 +110,7 @@ import tools.jackson.databind.ObjectMapper;
  * mode-matrix row keeps "the same surface, team-&gt;default" in engine mode too (J1 remap deferred
  * to E10) - in particular POST /workspace/&#123;workspace&#125;/workflow/&#123;name&#125;/submit,
  * the only HTTP route that starts a run, must work in engine mode against the single {@code system}
- * workspace (AM-10, EngineWorkspaceInterceptor).
+ * workspace (see EngineWorkspaceInterceptor).
  *
  * <p>Its two standalone-only collaborators are therefore held as ObjectProvider, not as fields:
  * workspace.WorkspaceService and schedule.ScheduleService are both

--- a/service-core/src/test/java/io/boomerang/core/TokenServiceSessionTest.java
+++ b/service-core/src/test/java/io/boomerang/core/TokenServiceSessionTest.java
@@ -30,8 +30,8 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
- * The session-minting core behind {@code POST /api/v2/auth/exchange} (specifications/authentication.md
- * §1): the raw {@code bfs_<uuid>} value must be recoverable by a caller that needs to hand it to a
+ * The session-minting core behind {@code POST /api/v2/auth/exchange}: the raw {@code bfs_<uuid>}
+ * value must be recoverable by a caller that needs to hand it to a
  * browser (the exchange endpoint's cookie), while the entity only ever persists its hash - and
  * {@code createSessionTokenForUser} must skip get-or-register entirely for an already-resolved user
  * (the proxy-exchange path, where AuthenticationFilter resolved/registered the user moments earlier).
@@ -108,7 +108,7 @@ class TokenServiceSessionTest {
   /*
    * AuthenticationFilter's header-resolved branches (forwarded email, raw JWT, Basic) call
    * createSessionToken on EVERY request - without reuse, each request persists a brand-new
-   * TokenEntity (specifications/authentication.md flags this write amplification).
+   * TokenEntity, which is pure write amplification.
    */
   @Test
   void repeatedFilterAuthenticationReusesTheMintedSessionToken() {

--- a/service-core/src/test/java/io/boomerang/core/security/AuthExchangeServiceTest.java
+++ b/service-core/src/test/java/io/boomerang/core/security/AuthExchangeServiceTest.java
@@ -29,8 +29,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.env.MockEnvironment;
 
 /**
- * The unified token exchange's two identity sources (specifications/authentication.md §1) at the
- * service layer - both converge on {@code TokenService}'s session-minting, and logout must revoke.
+ * The unified token exchange's two identity sources at the service layer - both converge on
+ * {@code TokenService}'s session-minting, and logout must revoke.
  */
 @ExtendWith(MockitoExtension.class)
 class AuthExchangeServiceTest {

--- a/service-core/src/test/java/io/boomerang/core/security/AuthenticationFilterTest.java
+++ b/service-core/src/test/java/io/boomerang/core/security/AuthenticationFilterTest.java
@@ -27,8 +27,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
 /**
- * The session cookie as an identity source, and the structured-401 fix (specifications/authentication.md
- * §1/§5): AuthenticationFilter must not disturb its existing header-based branches, must accept
+ * The session cookie as an identity source, and the structured 401: AuthenticationFilter must
+ * not disturb its existing header-based branches, must accept
  * SessionCookie.NAME as an additional source, and must route an unresolved identity through the
  * delegated entry point EXCEPT on the exchange endpoint's own path, which it must let through
  * unauthenticated (the OIDC login body verifies itself).

--- a/service-core/src/test/java/io/boomerang/core/security/EngineWorkspaceInterceptorTest.java
+++ b/service-core/src/test/java/io/boomerang/core/security/EngineWorkspaceInterceptorTest.java
@@ -21,11 +21,10 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 /**
- * Behavioural guard for AM-10: in engine mode, {@link EngineWorkspaceInterceptor} must reject any
+ * Behavioural guard: in engine mode, {@link EngineWorkspaceInterceptor} must reject any
  * workspace-scoped request whose {@code {workspace}} path variable is not {@code system}, while
- * letting {@code system} straight through to the real controller/service. H14-a retired the
- * deprecated {@code /api/v2/team/{team}} alias entirely, so only {@code /api/v2/workspace/}
- * remains to test.
+ * letting {@code system} straight through to the real controller/service. The deprecated
+ * {@code /api/v2/team/{team}} alias is gone, so only {@code /api/v2/workspace/} remains to test.
  *
  * <p>MockMvc is built from the real {@link WebApplicationContext} (same established pattern as
  * {@code DispatcherAuthTest}) so the request genuinely traverses Spring MVC's

--- a/service-core/src/test/java/io/boomerang/core/security/OidcTokenVerifierTest.java
+++ b/service-core/src/test/java/io/boomerang/core/security/OidcTokenVerifierTest.java
@@ -34,8 +34,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.client.RestTemplate;
 
 /**
- * Covers the OIDC direct-login path's cryptographic verification (specifications/authentication.md
- * §1/§5): a real RSA-signed JWT verified via a mocked JWKS/discovery response, so these exercise
+ * Covers the OIDC direct-login path's cryptographic verification: a real RSA-signed JWT verified
+ * via a mocked JWKS/discovery response, so these exercise
  * the actual nimbus-jose-jwt signature/claims verification pipeline rather than a stub.
  */
 @ExtendWith(MockitoExtension.class)

--- a/service-core/src/test/java/io/boomerang/core/security/SessionCookieTest.java
+++ b/service-core/src/test/java/io/boomerang/core/security/SessionCookieTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseCookie;
 
 /**
- * The session cookie's attributes are ruled, not incidental (specifications/authentication.md
- * §1): httpOnly + Secure + SameSite=Lax, carrying only the opaque value - never permissions.
+ * The session cookie's attributes are part of the contract, not incidental: httpOnly + Secure +
+ * SameSite=Lax, carrying only the opaque value - never permissions.
  */
 class SessionCookieTest {
 

--- a/service-core/src/test/java/io/boomerang/workflow/EngineModeWorkflowSubmitTest.java
+++ b/service-core/src/test/java/io/boomerang/workflow/EngineModeWorkflowSubmitTest.java
@@ -31,7 +31,7 @@ import org.springframework.test.context.TestPropertySource;
  * NoSuchBeanDefinitionException at request time. Boot still succeeded, which is exactly why no
  * mode-gating boot test caught it.
  *
- * <p>Engine mode serves the single {@code system} workspace (AM-10, EngineWorkspaceInterceptor),
+ * <p>Engine mode serves the single {@code system} workspace (see EngineWorkspaceInterceptor),
  * so this drives the real service against it.
  */
 @TestPropertySource(properties = "flow.mode=engine")


### PR DESCRIPTION
Fixes #395.

Second pass over the files deferred in #401 because the authentication branch (#320) was still open; that branch has since merged.

Comments and javadoc only - no code, string, identifier, or test-assertion changes. Each citation of a retired `specifications/` file (`authentication.md`, `merge-execution-plan.md`) is deleted; where the sentence then lost its point it now states what the code guarantees, and where a pointer genuinely helps the current file is named (`specifications/authorization.md`; `specifications/architecture.md` for the mode matrix). Process codes in the same comment blocks (`AM-10`, `T6-3`, `H14-a`, "BFF slice", "maintainer ruling <date>") are dropped with them.

## Files changed (28)

**service-core main (14)**
- `src/main/java/io/boomerang/core/AuthControllerV2.java` (now cites `specifications/authorization.md`)
- `src/main/java/io/boomerang/core/TokenService.java`
- `src/main/java/io/boomerang/core/model/AuthExchangeRequest.java`
- `src/main/java/io/boomerang/core/security/AuthExchangeService.java`
- `src/main/java/io/boomerang/core/security/AuthenticationFilter.java` (2 comments)
- `src/main/java/io/boomerang/core/security/EngineWorkspaceInterceptor.java`
- `src/main/java/io/boomerang/core/security/EngineWorkspaceInterceptorConfiguration.java` (now cites `specifications/architecture.md`)
- `src/main/java/io/boomerang/core/security/FlowAuthenticationException.java`
- `src/main/java/io/boomerang/core/security/OidcTokenVerifier.java`
- `src/main/java/io/boomerang/core/security/SecurityConfiguration.java`
- `src/main/java/io/boomerang/core/security/SessionCookie.java`
- `src/main/java/io/boomerang/core/security/UnauthenticatedGlobalToken.java` (now cites `specifications/authorization.md`)
- `src/main/java/io/boomerang/core/security/enums/AuthScope.java` (now cites `specifications/authorization.md`)
- `src/main/java/io/boomerang/core/security/enums/PermissionScope.java` (now cites `specifications/authorization.md`)
- `src/main/java/io/boomerang/workflow/WorkflowService.java` (`AM-10` only)

**service-core tests (8)**
- `src/test/java/io/boomerang/core/TokenServiceSessionTest.java` (2 comments)
- `src/test/java/io/boomerang/core/security/AuthExchangeServiceTest.java`
- `src/test/java/io/boomerang/core/security/AuthenticationFilterTest.java`
- `src/test/java/io/boomerang/core/security/EngineWorkspaceInterceptorTest.java`
- `src/test/java/io/boomerang/core/security/OidcTokenVerifierTest.java`
- `src/test/java/io/boomerang/core/security/SessionCookieTest.java`
- `src/test/java/io/boomerang/workflow/EngineModeWorkflowSubmitTest.java`

**client-web (6)**
- `src/Config/serverFetch.ts`
- `src/Config/servicesConfig.ts`
- `src/Features/Auth/Auth.action.node.spec.ts`
- `src/Features/Auth/Session.action.node.spec.ts`
- `src/Features/Auth/oidc.server.ts`
- `src/Features/Auth/session.server.ts`

`lib-common/.../BoomerangError.java` was already cleaned in #401 and had no remaining hits.

## Verification

- `grep -rnE 'specifications/(authentication|merge-execution-plan|consolidation-proposal|runtime-contract|task-contract-research|timeout-audit|queue-design)|framework-review-wave|ruling T6-3|AM-10'` over `service-core/src service-loader/src lib-common/src client-web/src` (`*.java`, `*.ts`, `*.tsx`) - 0 hits (was 30).
- `mvn -o -q -pl service-core,service-loader,lib-common -am compile` - exit 0 (Java 25); `mvn -o -q -pl service-core -am test-compile` - exit 0.
- `git diff -U0` contains no changed line that is not a `*`, `//` or `/*` comment line.
