### PR TITLE
fix: eight beta-review bugs across workspace, workflow, actions and the webapp

### DIFF
--- a/client-web/src/ApiServer/msw/handlers.ts
+++ b/client-web/src/ApiServer/msw/handlers.ts
@@ -442,6 +442,12 @@ export const handlers: HttpHandler[] = [
     const user = db.users.find((u) => u.id === params.userId);
     return user ? HttpResponse.json(user) : HttpResponse.json({ errors: ["User not found"] }, { status: 404 });
   }),
+  http.get(serviceUrl.getUserWorkspaces({ userId: ":userId" }), ({ params }) => {
+    const user = db.users.find((u) => u.id === params.userId);
+    return user
+      ? HttpResponse.json(db.workspaces)
+      : HttpResponse.json({ errors: ["User not found"] }, { status: 400 });
+  }),
   http.patch(serviceUrl.getUser({ userId: ":userId" }), async ({ params, request }) => {
     const index = db.users.findIndex((u) => u.id === params.userId);
     if (index === -1) return HttpResponse.json({ errors: ["User not found"] }, { status: 404 });

--- a/client-web/src/Components/SchedulePanelDetail/SchedulePanelDetail.tsx
+++ b/client-web/src/Components/SchedulePanelDetail/SchedulePanelDetail.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, CodeSnippet } from "@carbon/react";
+import { Button, CodeSnippet, Tag } from "@carbon/react";
 import { TooltipHover } from "@boomerang-io/carbon-addons-boomerang-react";
 import SlidingPane from "react-sliding-pane";
 import cronstrue from "cronstrue";
@@ -36,14 +36,13 @@ export default function SchedulePanelDetail(props: SchedulePanelDetailProps) {
     );
 
     const labels: React.ReactNode[] = [];
-    //TODO: fix labels
-    // for (const entry of schedule?.labels || []) {
-    //   labels.push(
-    //     <Tag key={entry.key} style={{ marginLeft: 0 }} type="teal">
-    //       {entry.key}:{entry.value}
-    //     </Tag>
-    //   );
-    // }
+    Object.entries(schedule.labels ?? {}).forEach(([key, value]) => {
+      labels.push(
+        <Tag key={key} style={{ marginLeft: 0 }} type="teal">
+          {`${key}=${value}`}
+        </Tag>,
+      );
+    });
 
     return (
       <>

--- a/client-web/src/Components/SchedulePanelList/SchedulePanelList.tsx
+++ b/client-web/src/Components/SchedulePanelList/SchedulePanelList.tsx
@@ -57,7 +57,13 @@ export default function SchedulePanelList(props: SchedulePanelListProps) {
     if (schedules) {
       const filteredSchedules = Boolean(filterQuery)
         ? matchSorter(schedules, filterQuery, {
-            keys: ["name", "description", "type", "status", "labels.0.key", "labels.0.value"],
+            keys: [
+              "name",
+              "description",
+              "type",
+              "status",
+              (schedule) => Object.entries(schedule.labels ?? {}).map(([key, value]) => `${key}=${value}`),
+            ],
             threshold: matchSorter.rankings.CONTAINS,
           })
         : schedules;
@@ -225,13 +231,11 @@ function ScheduledListItem(props: ScheduledListItemProps) {
 
   // Determine some things for rendering
   const isActive = props.schedule.status === "active";
-  // Iterate through labels: Record<string, string>
   const labels: Array<React.ReactNode> = [];
-  //TODO figure out labels
-  Object.entries(props.schedule?.labels || {}).forEach(([index, value]) => {
+  Object.entries(props.schedule.labels ?? {}).forEach(([key, value]) => {
     labels.push(
-      <Tag key={index} style={{ marginLeft: 0 }} type="teal">
-        {/* ${value} */}
+      <Tag key={key} style={{ marginLeft: 0 }} type="teal">
+        {`${key}=${value}`}
       </Tag>,
     );
   });

--- a/client-web/src/Config/servicesConfig.ts
+++ b/client-web/src/Config/servicesConfig.ts
@@ -84,6 +84,7 @@ export const serviceUrl = {
   getTokenCatalog: ({ query }) => `${BASE_URL}/token/catalog${query ? "?" + query : ""}`,
   getUsers: ({ query }: QueryArg) => `${BASE_URL}/user/query${query ? "?" + query : ""}`,
   getUser: ({ userId }) => `${BASE_URL}/user/${userId}`,
+  getUserWorkspaces: ({ userId }) => `${BASE_URL}/user/${userId}/workspaces`,
   deleteUser: ({ userId }) => `${BASE_URL}/user/${userId}`,
   getUserProfile: () => `${BASE_URL}/profile`,
   getIntegrations: ({ workspace }: WorkspaceArg) => `${BASE_URL}/integration${workspace ? "?workspace=" + workspace : ""}`,

--- a/client-web/src/Features/UserDetailed/UserDetailed.tsx
+++ b/client-web/src/Features/UserDetailed/UserDetailed.tsx
@@ -5,11 +5,10 @@ import { useFeature } from "flagged";
 import { Helmet } from "react-helmet";
 import { Route, Routes, useLoaderData } from "react-router-dom";
 import { Box } from "reflexbox";
-import { useAppContext } from "Hooks";
 import { FeatureFlag } from "Config/appConfig";
 import { serviceUrl } from "Config/servicesConfig";
 import { serverFetch } from "Config/serverFetch";
-import { FlowUser } from "Types";
+import { FlowUser, FlowWorkspaceSummary } from "Types";
 import { actionError, type ActionError } from "Utils/actionResult";
 import Header from "./Header";
 import Labels from "./Labels";
@@ -24,6 +23,7 @@ import styles from "./UserDetailed.module.scss";
 // resolves but fails.
 type LoaderData = {
   userDetails: FlowUser | null;
+  workspaces: Array<FlowWorkspaceSummary>;
   errorLoading: boolean;
 };
 
@@ -38,12 +38,17 @@ export async function loader({
   params: { userId?: string };
   request: Request;
 }): Promise<LoaderData> {
-  const userDetailsUrl = serviceUrl.getUser({ userId: params.userId });
+  const fetch = serverFetch(request);
   try {
-    const response = await serverFetch(request).get(userDetailsUrl);
-    return { userDetails: response.data, errorLoading: false };
+    // The Workspaces tab must show the VIEWED user's memberships, not the signed-in viewer's
+    // (AppContext.workspaces), so both the user record and their workspace rollup load here.
+    const [userResponse, workspacesResponse] = await Promise.all([
+      fetch.get(serviceUrl.getUser({ userId: params.userId })),
+      fetch.get(serviceUrl.getUserWorkspaces({ userId: params.userId })),
+    ]);
+    return { userDetails: userResponse.data, workspaces: workspacesResponse.data, errorLoading: false };
   } catch (error) {
-    return { userDetails: null, errorLoading: true };
+    return { userDetails: null, workspaces: [], errorLoading: true };
   }
 }
 
@@ -109,8 +114,7 @@ const FeatureLayout = ({ children, isError }: FeatureLayoutProps) => {
 
 function WorkspaceDetailedContainer() {
   const userManagementEnabled = useFeature(FeatureFlag.UserManagementEnabled);
-  const { workspaces } = useAppContext();
-  const { userDetails, errorLoading } = useLoaderData() as LoaderData;
+  const { userDetails, workspaces, errorLoading } = useLoaderData() as LoaderData;
 
   if (errorLoading || !userDetails) {
     return (

--- a/client-web/src/Features/WorkflowEditor/Configure/BuildWebhookModalContent/BuildWebhookModalContent.tsx
+++ b/client-web/src/Features/WorkflowEditor/Configure/BuildWebhookModalContent/BuildWebhookModalContent.tsx
@@ -13,7 +13,7 @@ interface BuildWebhookModalContentProps {
 
 const BuildWebhookModalContent: React.FC<BuildWebhookModalContentProps> = ({ workflowRef, closeModal }) => {
   const resourceUrl = serviceUrl.resourceTrigger();
-  const webhookURL = `${resourceUrl}/webhook?workflow=${workflowRef}`;
+  const webhookURL = `${resourceUrl}/webhook?ref=${workflowRef}`;
 
   return (
     <ModalForm>
@@ -37,7 +37,7 @@ const BuildWebhookModalContent: React.FC<BuildWebhookModalContentProps> = ({ wor
               className={styles.codeSnippet}
             >
               POST{"  "}
-              {`${resourceUrl}/webhook?workflow=${workflowRef}
+              {`${resourceUrl}/webhook?ref=${workflowRef}
                 &access_token=`}
             </CodeSnippet>
           </>

--- a/client-web/src/Features/WorkflowEditor/Configure/ConfigureEventTrigger/ConfigureEventTrigger.tsx
+++ b/client-web/src/Features/WorkflowEditor/Configure/ConfigureEventTrigger/ConfigureEventTrigger.tsx
@@ -28,7 +28,7 @@ type Props = {
 
 export default function ConfigureStorage({ closeModal, workflowRef }: Props) {
   const resourceUrl = serviceUrl.resourceTrigger();
-  const webhookURL = `${resourceUrl}/event?workflow=${workflowRef}`;
+  const webhookURL = `${resourceUrl}/event?ref=${workflowRef}`;
 
   return (
     <ModalForm>
@@ -49,7 +49,7 @@ export default function ConfigureStorage({ closeModal, workflowRef }: Props) {
           className={styles.codeSnippet}
         >
           POST{"  "}
-          {`${resourceUrl}/event?workflow=${workflowRef}&access_token=TOKEN`}
+          {`${resourceUrl}/event?ref=${workflowRef}&access_token=TOKEN`}
         </CodeSnippet>
         <h2 className={styles.sectionHeader}>Example Payload</h2>
         <p>

--- a/client-web/src/Features/WorkspaceDetailed/ApproverGroups/ApproverGroups.tsx
+++ b/client-web/src/Features/WorkspaceDetailed/ApproverGroups/ApproverGroups.tsx
@@ -71,7 +71,7 @@ export async function action({ params, request }: { params: { workspace?: string
   const groupId = formData.get("groupId") ? String(formData.get("groupId")) : null;
   const approverGroup = {
     name: String(formData.get("name")),
-    groupId,
+    id: groupId,
     approvers: JSON.parse(String(formData.get("approvers"))),
   };
   try {

--- a/client-web/src/Features/WorkspaceDetailed/WorkspaceDetailed.spec.tsx
+++ b/client-web/src/Features/WorkspaceDetailed/WorkspaceDetailed.spec.tsx
@@ -329,6 +329,27 @@ describe("WorkspaceDetailed --- approver groups action", () => {
     expect(result.isEdit).toBe(false);
   });
 
+  test("edits send the group id so the backend updates the group rather than creating one", async () => {
+    let patchBody: { approverGroups: Array<Record<string, unknown>> } | undefined;
+    server.use(
+      http.patch(serviceUrl.resourceWorkspace({ workspace: ":workspace" }), async ({ request }) => {
+        patchBody = (await request.json()) as typeof patchBody;
+        return HttpResponse.json(workspaceFixture);
+      }),
+    );
+    const result = await submit({
+      intent: "saveApproverGroup",
+      isEdit: "true",
+      groupId: "some-group-id",
+      name: "Renamed Group",
+      approvers: JSON.stringify(["user-1"]),
+    });
+    expect(isActionError(result)).toBe(false);
+    expect(patchBody?.approverGroups).toEqual([
+      { name: "Renamed Group", id: "some-group-id", approvers: ["user-1"] },
+    ]);
+  });
+
   test("surfaces a failed save without throwing", async () => {
     server.use(
       http.patch(serviceUrl.resourceWorkspace({ workspace: ":workspace" }), () =>

--- a/client-web/src/Features/Workspaces/Workspaces.tsx
+++ b/client-web/src/Features/Workspaces/Workspaces.tsx
@@ -80,10 +80,8 @@ type LoaderData = {
 // the same order/page/limit/sort search params the component below parses off `location.search`
 // - kept as parallel, not shared, logic: the loader only has `request.url` to work with, and the
 // component still needs order/sort for its own display concerns (sort-header state, pagination
-// controls) independent of the fetch. Note `query` (the search box's debounced param) is parsed
-// into the URL but was never actually forwarded to the API by the pre-loader code either - that
-// existing behaviour (search box updates the URL but doesn't filter server-side) is preserved
-// as-is rather than "fixed" as part of this conversion.
+// controls) independent of the fetch. The search box's debounced `query` param is forwarded to
+// the API as `search` (anchored case-insensitive prefix match on name/displayName).
 export async function loader({ request }: { request: Request }): Promise<LoaderData> {
   const url = new URL(request.url);
   const parsedQuery = queryString.parse(url.search, queryStringOptions);
@@ -91,8 +89,9 @@ export async function loader({ request }: { request: Request }): Promise<LoaderD
   const page = parsedQuery.page ?? DEFAULT_PAGE;
   const limit = parsedQuery.limit ?? DEFAULT_LIMIT;
   const sort = typeof parsedQuery.sort === "string" ? parsedQuery.sort : DEFAULT_SORT;
+  const search = typeof parsedQuery.query === "string" ? parsedQuery.query : undefined;
 
-  const workspacesUrlQuery = queryString.stringify({ order, page, limit, sort });
+  const workspacesUrlQuery = queryString.stringify({ order, page, limit, sort, search }, { skipEmptyString: true });
 
   try {
     const response = await serverFetch(request).get(serviceUrl.getWorkspaces({ query: workspacesUrlQuery }));

--- a/service-core/src/main/java/io/boomerang/workflow/ActionService.java
+++ b/service-core/src/main/java/io/boomerang/workflow/ActionService.java
@@ -14,6 +14,7 @@ import io.boomerang.core.UserService;
 import io.boomerang.core.model.Token;
 import io.boomerang.core.security.IdentityService;
 import io.boomerang.core.entity.UserEntity;
+import io.boomerang.core.enums.RelationshipLabel;
 import io.boomerang.core.enums.RelationshipType;
 import io.boomerang.core.model.User;
 import io.boomerang.common.error.BoomerangError;
@@ -225,6 +226,17 @@ public class ActionService {
     String displayName = workflow.getDisplayName();
     action.setWorkflowName(
         displayName != null && !displayName.isBlank() ? displayName : workflow.getName());
+    // The owning Workspace is resolved fresh from the relationship graph (never stored on
+    // ActionEntity); its slug is the name the webapp displays and routes on.
+    String workspaceRef =
+        relationshipService.getParentByLabel(
+            RelationshipLabel.HAS_WORKFLOW,
+            RelationshipType.WORKFLOW,
+            actionEntity.getWorkflowRef());
+    if (workspaceRef != null && !workspaceRef.isBlank()) {
+      action.setWorkspaceName(
+          relationshipService.getSlugByRefForType(RelationshipType.WORKSPACE, workspaceRef));
+    }
     try {
       TaskRun taskRun = engineTaskRunService.get(actionEntity.getTaskRunRef()).getBody();
       action.setTaskName(taskRun.getName());

--- a/service-core/src/main/java/io/boomerang/workflow/WorkflowService.java
+++ b/service-core/src/main/java/io/boomerang/workflow/WorkflowService.java
@@ -1672,6 +1672,12 @@ public class WorkflowService {
     if (workflow.getDescription() != null && !workflow.getDescription().isBlank()) {
       workflowEntity.setDescription(workflow.getDescription());
     }
+    if (workflow.getDisplayName() != null && !workflow.getDisplayName().isBlank()) {
+      workflowEntity.setDisplayName(workflow.getDisplayName());
+    }
+    if (workflow.getIcon() != null && !workflow.getIcon().isBlank()) {
+      workflowEntity.setIcon(workflow.getIcon());
+    }
     if (workflow.getLabels() != null && !workflow.getLabels().isEmpty()) {
       if (replace) {
         workflowEntity.setLabels(workflow.getLabels());

--- a/service-core/src/main/java/io/boomerang/workflow/model/Action.java
+++ b/service-core/src/main/java/io/boomerang/workflow/model/Action.java
@@ -7,7 +7,7 @@ public class Action extends ActionEntity {
 
   private String taskName;
   private String workflowName;
-  private String teamName;
+  private String workspaceName;
   private long numberOfApprovals;
   private long approvalsRequired;
 
@@ -33,12 +33,12 @@ public class Action extends ActionEntity {
     this.workflowName = workflowName;
   }
 
-  public String getTeamName() {
-    return teamName;
+  public String getWorkspaceName() {
+    return workspaceName;
   }
 
-  public void setTeamName(String teamName) {
-    this.teamName = teamName;
+  public void setWorkspaceName(String workspaceName) {
+    this.workspaceName = workspaceName;
   }
 
   public long getApprovalsRequired() {

--- a/service-core/src/main/java/io/boomerang/workspace/UserWorkspaceControllerV2.java
+++ b/service-core/src/main/java/io/boomerang/workspace/UserWorkspaceControllerV2.java
@@ -1,0 +1,60 @@
+package io.boomerang.workspace;
+
+import io.boomerang.common.error.BoomerangError;
+import io.boomerang.common.error.BoomerangException;
+import io.boomerang.config.ConditionalOnFlowMode;
+import io.boomerang.config.FlowMode;
+import io.boomerang.core.UserService;
+import io.boomerang.core.security.AuthCriteria;
+import io.boomerang.core.security.enums.AuthScope;
+import io.boomerang.core.security.enums.PermissionAction;
+import io.boomerang.core.security.enums.PermissionResource;
+import io.boomerang.workspace.model.WorkspaceSummary;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/*
+ * Serves a given user's Workspace membership rollup, the same composition ProfileControllerV2
+ * performs for the current user.
+ *
+ * Lives in workspace, not core beside UserControllerV2, for the same reason as ProfileControllerV2:
+ * the rollup spans core (User) and workspace (Workspace) data, and io.boomerang.core has zero
+ * outbound feature-package imports.
+ */
+@RestController
+@RequestMapping("/api/v2/user")
+@Tag(name = "Users", description = "List, Create, update and delete Users.")
+@ConditionalOnFlowMode(FlowMode.STANDALONE)
+public class UserWorkspaceControllerV2 {
+
+  @Autowired private UserService userService;
+
+  @Autowired private WorkspaceService workspaceService;
+
+  @GetMapping(value = "/{userId}/workspaces")
+  @AuthCriteria(
+      action = PermissionAction.READ,
+      resource = PermissionResource.USER,
+      assignableScopes = {AuthScope.session, AuthScope.user, AuthScope.key, AuthScope.global})
+  @Operation(summary = "Get a Users Workspace memberships")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "400", description = "Bad Request")
+      })
+  public List<WorkspaceSummary> getUserWorkspaces(@PathVariable String userId) {
+    userService
+        .getUserByID(userId)
+        .orElseThrow(() -> new BoomerangException(BoomerangError.USER_NOT_FOUND));
+    return workspaceService.getWorkspaceMembershipSummary(
+        userService.getTeamRefsAndRolesForUser(userId));
+  }
+}

--- a/service-core/src/main/java/io/boomerang/workspace/WorkspaceService.java
+++ b/service-core/src/main/java/io/boomerang/workspace/WorkspaceService.java
@@ -276,6 +276,9 @@ public class WorkspaceService {
       if (request.getStatus() != null) {
         workspaceEntity.setStatus(request.getStatus());
       }
+      if (request.getType() != null) {
+        workspaceEntity.setType(request.getType());
+      }
       if (request.getExternalRef() != null && !request.getExternalRef().isBlank()) {
         workspaceEntity.setExternalRef(request.getExternalRef());
       }

--- a/service-core/src/main/java/io/boomerang/workspace/WorkspaceService.java
+++ b/service-core/src/main/java/io/boomerang/workspace/WorkspaceService.java
@@ -635,9 +635,15 @@ public class WorkspaceService {
         throw new BoomerangException(BoomerangError.TEAM_INVALID_REF);
       }
 
+      // Match by id when supplied so a rename updates the existing group; name matching is the
+      // fallback for requests that carry no id.
       ApproverGroupEntity age =
           approverGroupEntities.stream()
-              .filter(e -> e.getName().equalsIgnoreCase(r.getName()))
+              .filter(
+                  e ->
+                      (r.getId() != null && !r.getId().isBlank())
+                          ? r.getId().equals(e.getId())
+                          : e.getName().equalsIgnoreCase(r.getName()))
               .findFirst()
               .orElse(null);
 
@@ -658,9 +664,9 @@ public class WorkspaceService {
                   .collect(Collectors.toList());
           LOGGER.debug("Valid Approver Refs: " + validApproverRefs.toString());
           age.setApprovers(validApproverRefs);
-
-          age = approverGroupRepository.save(age);
         }
+        // Save outside the approvers guard so a rename without an approvers list still persists.
+        approverGroupRepository.save(age);
       } else {
         // ApproverGroup + Relationship needs creating
         ApproverGroupEntity approverGroupEntity = new ApproverGroupEntity();
@@ -690,14 +696,17 @@ public class WorkspaceService {
     }
   }
 
-  // Retrieve ApproverGroups by relationship as they are stored separately to the WorkspaceEntity
+  // Retrieve ApproverGroups by relationship as they are stored separately to the WorkspaceEntity.
+  // The relationship node's ref is the group id (its slug is the name), so ask for refs - the
+  // repository lookup below is by id.
   private List<ApproverGroupEntity> getApproverGroupsForTeam(String team) {
     List<String> approverGroupRefs =
         relationshipService.filter(
             RelationshipType.APPROVERGROUP,
             Optional.empty(),
             Optional.of(RelationshipType.WORKSPACE),
-            Optional.of(List.of(team)));
+            Optional.of(List.of(team)),
+            false);
     List<ApproverGroupEntity> approverGroupEntities =
         approverGroupRepository.findByIdIn(approverGroupRefs);
     return approverGroupEntities;

--- a/service-core/src/main/java/io/boomerang/workspace/model/Workspace.java
+++ b/service-core/src/main/java/io/boomerang/workspace/model/Workspace.java
@@ -19,6 +19,7 @@ public class Workspace {
   private String name;
   private String displayName;
   private Date creationDate = new Date();
+  private WorkspaceType type;
   private WorkspaceStatus status = WorkspaceStatus.active;
   private String externalRef;
   private Map<String, String> labels = new HashMap<>();
@@ -65,6 +66,14 @@ public class Workspace {
 
   public void setCreationDate(Date creationDate) {
     this.creationDate = creationDate;
+  }
+
+  public WorkspaceType getType() {
+    return type;
+  }
+
+  public void setType(WorkspaceType type) {
+    this.type = type;
   }
 
   public WorkspaceStatus getStatus() {

--- a/service-core/src/test/java/io/boomerang/workflow/ActionServiceTest.java
+++ b/service-core/src/test/java/io/boomerang/workflow/ActionServiceTest.java
@@ -13,6 +13,8 @@ import io.boomerang.common.model.Workflow;
 import io.boomerang.core.RelationshipService;
 import io.boomerang.core.UserService;
 import io.boomerang.core.entity.UserEntity;
+import io.boomerang.core.enums.RelationshipLabel;
+import io.boomerang.core.enums.RelationshipType;
 import io.boomerang.engine.TaskRunService;
 import io.boomerang.engine.repository.ActionRepository;
 import io.boomerang.workflow.model.Action;
@@ -184,5 +186,29 @@ class ActionServiceTest {
     Action action = actionService.get("team1", "a1");
 
     assertThat(action.getWorkflowName()).isEqualTo("my-workflow-slug");
+  }
+
+  // The approval modal's Workspace field: the owning Workspace is resolved fresh from the
+  // relationship graph via the Action's Workflow, never stored on ActionEntity.
+  @Test
+  void getResolvesWorkspaceNameFromOwningWorkspace() {
+    ActionEntity entity = manualAction();
+    when(actionRepository.findById("a1")).thenReturn(Optional.of(entity));
+
+    Workflow workflow = new Workflow();
+    workflow.setName("my-workflow-slug");
+    workflow.setDisplayName("My Workflow");
+    when(workflowService.get("w1", Optional.empty(), false))
+        .thenReturn(ResponseEntity.ok(workflow));
+    when(engineTaskRunService.get(any())).thenReturn(ResponseEntity.ok(new TaskRun()));
+    when(relationshipService.getParentByLabel(
+            RelationshipLabel.HAS_WORKFLOW, RelationshipType.WORKFLOW, "w1"))
+        .thenReturn("ws1");
+    when(relationshipService.getSlugByRefForType(RelationshipType.WORKSPACE, "ws1"))
+        .thenReturn("my-workspace");
+
+    Action action = actionService.get("team1", "a1");
+
+    assertThat(action.getWorkspaceName()).isEqualTo("my-workspace");
   }
 }

--- a/service-core/src/test/java/io/boomerang/workflow/WorkflowTaskParamValidationTest.java
+++ b/service-core/src/test/java/io/boomerang/workflow/WorkflowTaskParamValidationTest.java
@@ -112,6 +112,26 @@ class WorkflowTaskParamValidationTest extends AbstractEngineIntegrationTest {
   }
 
   @Test
+  void updatePreservesDisplayNameAndIcon() {
+    String taskSlug = declaredParamTask("param-validation-display", "greeting");
+    Workflow workflow =
+        workflowWithTaskParams(
+            "param-validation-display-wf", taskSlug, new RunParam("greeting", "hi"));
+    workflowService.create(WORKSPACE, workflow);
+
+    Workflow update =
+        workflowWithTaskParams(
+            "param-validation-display-wf", taskSlug, new RunParam("greeting", "hi"));
+    update.setDisplayName("Renamed Workflow");
+    update.setIcon("bot");
+
+    Workflow applied = workflowService.apply(WORKSPACE, update, false);
+
+    assertEquals("Renamed Workflow", applied.getDisplayName());
+    assertEquals("bot", applied.getIcon());
+  }
+
+  @Test
   void aNodeParamThatCaseVariesFromTheDeclaredNameIsAccepted() {
     String taskSlug = declaredParamTask("param-validation-case", "githubToken");
     Workflow workflow =

--- a/service-core/src/test/java/io/boomerang/workspace/UserWorkspaceControllerV2Test.java
+++ b/service-core/src/test/java/io/boomerang/workspace/UserWorkspaceControllerV2Test.java
@@ -1,0 +1,69 @@
+package io.boomerang.workspace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import io.boomerang.common.error.BoomerangException;
+import io.boomerang.core.UserService;
+import io.boomerang.core.model.User;
+import io.boomerang.workspace.model.WorkspaceSummary;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * {@code GET /api/v2/user/&#123;userId&#125;/workspaces} backs the admin User detail Workspaces
+ * tab. The rollup must be resolved for the VIEWED user's id - the same
+ * getTeamRefsAndRolesForUser/getWorkspaceMembershipSummary composition ProfileControllerV2 performs
+ * for the current user - and an unknown id must fail as USER_NOT_FOUND rather than return an empty
+ * (or the caller's own) membership list.
+ */
+@ExtendWith(MockitoExtension.class)
+class UserWorkspaceControllerV2Test {
+
+  private static final String USER_ID = "5f170b3df6ab327e302cb0a5";
+
+  @Mock private UserService userService;
+  @Mock private WorkspaceService workspaceService;
+
+  private UserWorkspaceControllerV2 controller;
+
+  @BeforeEach
+  void setUp() {
+    controller = new UserWorkspaceControllerV2();
+    ReflectionTestUtils.setField(controller, "userService", userService);
+    ReflectionTestUtils.setField(controller, "workspaceService", workspaceService);
+  }
+
+  @Test
+  void resolvesMembershipForTheViewedUser() {
+    WorkspaceSummary summary = new WorkspaceSummary();
+    summary.setName("test-workspace");
+    when(userService.getUserByID(USER_ID)).thenReturn(Optional.of(new User()));
+    when(userService.getTeamRefsAndRolesForUser(USER_ID)).thenReturn(Map.of("ref", "owner"));
+    when(workspaceService.getWorkspaceMembershipSummary(Map.of("ref", "owner")))
+        .thenReturn(List.of(summary));
+
+    List<WorkspaceSummary> workspaces = controller.getUserWorkspaces(USER_ID);
+
+    assertThat(workspaces).hasSize(1);
+    assertThat(workspaces.get(0).getName()).isEqualTo("test-workspace");
+  }
+
+  @Test
+  void unknownUserFailsInsteadOfReturningEmptyMembership() {
+    when(userService.getUserByID(USER_ID)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> controller.getUserWorkspaces(USER_ID))
+        .isInstanceOf(BoomerangException.class)
+        .extracting("reason")
+        .isEqualTo("USER_NOT_FOUND");
+  }
+}

--- a/service-core/src/test/java/io/boomerang/workspace/WorkspaceApproverGroupUpdateTest.java
+++ b/service-core/src/test/java/io/boomerang/workspace/WorkspaceApproverGroupUpdateTest.java
@@ -1,0 +1,59 @@
+package io.boomerang.workspace;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.boomerang.engine.AbstractEngineIntegrationTest;
+import io.boomerang.workspace.model.ApproverGroupRequest;
+import io.boomerang.workspace.model.Workspace;
+import io.boomerang.workspace.model.WorkspaceRequest;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * An approver-group edit carries the group's id, so a rename must update that group in place
+ * rather than create a second group under the new name.
+ */
+class WorkspaceApproverGroupUpdateTest extends AbstractEngineIntegrationTest {
+
+  @Autowired private WorkspaceService workspaceService;
+
+  @BeforeEach
+  void seedFixtures() {
+    seedRelationshipRoot();
+    seedTeamQuotaSettings();
+  }
+
+  @Test
+  void renamingAnApproverGroupByIdUpdatesTheExistingGroup() {
+    String workspaceName = "approver-group-rename-workspace-test";
+    WorkspaceRequest createRequest = new WorkspaceRequest();
+    createRequest.setName(workspaceName);
+    createRequest.setDisplayName(workspaceName);
+    workspaceService.create(createRequest);
+
+    // Groups are added through the workspace patch, matching the webapp's flow.
+    ApproverGroupRequest group = new ApproverGroupRequest();
+    group.setName("Release Approvers");
+    group.setApprovers(List.of());
+    WorkspaceRequest addRequest = new WorkspaceRequest();
+    addRequest.setApproverGroups(List.of(group));
+    Workspace created = workspaceService.patch(workspaceName, addRequest);
+    assertEquals(1, created.getApproverGroups().size());
+    String groupId = created.getApproverGroups().get(0).getId();
+
+    ApproverGroupRequest rename = new ApproverGroupRequest();
+    rename.setId(groupId);
+    rename.setName("Deploy Approvers");
+    rename.setApprovers(List.of());
+    WorkspaceRequest patchRequest = new WorkspaceRequest();
+    patchRequest.setApproverGroups(List.of(rename));
+
+    Workspace patched = workspaceService.patch(workspaceName, patchRequest);
+
+    assertEquals(1, patched.getApproverGroups().size(), "a rename must not create a second group");
+    assertEquals(groupId, patched.getApproverGroups().get(0).getId());
+    assertEquals("Deploy Approvers", patched.getApproverGroups().get(0).getName());
+  }
+}

--- a/service-core/src/test/java/io/boomerang/workspace/WorkspaceTypePatchTest.java
+++ b/service-core/src/test/java/io/boomerang/workspace/WorkspaceTypePatchTest.java
@@ -1,0 +1,45 @@
+package io.boomerang.workspace;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.boomerang.engine.AbstractEngineIntegrationTest;
+import io.boomerang.workspace.model.Workspace;
+import io.boomerang.workspace.model.WorkspaceRequest;
+import io.boomerang.workspace.model.WorkspaceType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/** The workspace type set at create is returned on read and changeable through patch. */
+class WorkspaceTypePatchTest extends AbstractEngineIntegrationTest {
+
+  @Autowired private WorkspaceService workspaceService;
+
+  @BeforeEach
+  void seedFixtures() {
+    seedRelationshipRoot();
+    seedTeamQuotaSettings();
+  }
+
+  @Test
+  void typeIsReturnedOnCreateAndHonouredOnPatch() {
+    String workspaceName = "workspace-type-patch-test";
+    WorkspaceRequest createRequest = new WorkspaceRequest();
+    createRequest.setName(workspaceName);
+    createRequest.setDisplayName(workspaceName);
+    createRequest.setType(WorkspaceType.hobby);
+    Workspace created = workspaceService.create(createRequest);
+    assertEquals(WorkspaceType.hobby, created.getType());
+
+    WorkspaceRequest patchRequest = new WorkspaceRequest();
+    patchRequest.setType(WorkspaceType.pro);
+    Workspace patched = workspaceService.patch(workspaceName, patchRequest);
+    assertEquals(WorkspaceType.pro, patched.getType());
+
+    // A patch that omits type leaves the stored value untouched.
+    WorkspaceRequest untouchedRequest = new WorkspaceRequest();
+    untouchedRequest.setDisplayName("renamed display");
+    Workspace untouched = workspaceService.patch(workspaceName, untouchedRequest);
+    assertEquals(WorkspaceType.pro, untouched.getType());
+  }
+}


### PR DESCRIPTION
Fixes the eight bugs found reviewing 5.0.0-beta.1. One commit per issue.

| Issue | Fix |
| --- | --- |
| Fixes #385 | Trigger URLs rendered by the workflow editor now use `?ref=`, matching what `WebhookEventControllerV2` reads. |
| Fixes #386 | The Workspaces route loader forwards the search term as `search=`, so the list filters server-side. |
| Fixes #387 | Schedule labels render as `key=value` tags in the detail panel, and the list's label search iterates the label map instead of array-shaped keys. |
| Fixes #388 | Approver groups are matched by `id` on update (name fallback only when no id), and the webapp sends `id`. Also fixes the read path: `getApproverGroupsForTeam` was feeding relationship slugs into `findByIdIn`, so the existing-group list was always empty and every save duplicated. |
| Fixes #389 | `Action.teamName` renamed to `workspaceName` and populated from the run's owning workspace via the relationship graph, so the approval modal shows the workspace. |
| Fixes #390 | Workspace `type` is exposed on the public model and honoured on patch (entity already stored it — wire-model completion only). |
| Fixes #391 | New `GET /api/v2/user/{userId}/workspaces` (`UserWorkspaceControllerV2`, same `@AuthCriteria` as `GET /user/{userId}`, same membership composition as the profile); the admin User Detail Workspaces tab reads it instead of the viewer's own memberships. |
| Fixes #392 | The workflow update path copies `displayName` and `icon` with the same guard as `description`, so edits are no longer silently dropped. |

New tests: `WorkspaceApproverGroupUpdateTest`, `WorkspaceTypePatchTest`, `UserWorkspaceControllerV2Test`, plus new cases in `ActionServiceTest`, `WorkflowTaskParamValidationTest`, and `WorkspaceDetailed.spec.tsx`.

Verification on the combined branch: `mvn -pl service-core test` over the five touched test classes — 19 tests, 0 failures (Testcontainers); vitest over the six touched frontend areas — 53/53.
