### PR TITLE
fix(client-web): trigger URLs use ?ref= as the API expects (#385)

### DIFF
--- a/client-web/src/Features/WorkflowEditor/Configure/BuildWebhookModalContent/BuildWebhookModalContent.spec.tsx
+++ b/client-web/src/Features/WorkflowEditor/Configure/BuildWebhookModalContent/BuildWebhookModalContent.spec.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import copy from "copy-to-clipboard";
+import { serviceUrl } from "Config/servicesConfig";
+import { renderWithRouter } from "Utils/testing/render";
+import BuildWebhookModalContent from "./index";
+
+vi.mock("copy-to-clipboard", () => ({ default: vi.fn() }));
+
+const WORKFLOW_REF = "5eb2c4085a92d80001a16d87";
+
+/*
+ * Regression spec for boomerang-io/flow#385: the editor rendered the copyable webhook trigger
+ * URL with a `workflow=` query parameter, but POST /api/v2/webhook only reads `ref=`
+ * (WebhookEventControllerV2), so pasting the displayed URL returned a 400.
+ */
+describe("BuildWebhookModalContent", () => {
+  it("renders and copies the webhook trigger URL with ?ref=, not ?workflow=", async () => {
+    const { container } = renderWithRouter(
+      <BuildWebhookModalContent workflowRef={WORKFLOW_REF} closeModal={() => {}} />,
+    );
+
+    // The displayed snippet (the template literal wraps before &access_token=, so match textContent).
+    expect(container.textContent).toContain(`${serviceUrl.resourceTrigger()}/webhook?ref=${WORKFLOW_REF}`);
+    expect(container.textContent).not.toContain(`webhook?workflow=`);
+
+    // The copy button hands the same ?ref= URL to the clipboard.
+    await userEvent.click(screen.getByRole("button", { name: /copy url/i }));
+    expect(copy).toHaveBeenCalledWith(`${serviceUrl.resourceTrigger()}/webhook?ref=${WORKFLOW_REF}`);
+  });
+});

--- a/client-web/src/Features/WorkflowEditor/Configure/ConfigureEventTrigger/ConfigureEventTrigger.spec.tsx
+++ b/client-web/src/Features/WorkflowEditor/Configure/ConfigureEventTrigger/ConfigureEventTrigger.spec.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import copy from "copy-to-clipboard";
+import { serviceUrl } from "Config/servicesConfig";
+import { renderWithRouter } from "Utils/testing/render";
+import ConfigureEventTrigger from "./index";
+
+vi.mock("copy-to-clipboard", () => ({ default: vi.fn() }));
+
+const WORKFLOW_REF = "5eb2c4085a92d80001a16d87";
+
+/*
+ * Regression spec for boomerang-io/flow#385: the editor rendered the copyable event trigger
+ * URL with a `workflow=` query parameter, but POST /api/v2/event only reads `ref=`
+ * (WebhookEventControllerV2), so the displayed URL never targeted the workflow.
+ */
+describe("ConfigureEventTrigger", () => {
+  it("renders and copies the event trigger URL with ?ref=, not ?workflow=", async () => {
+    const { container } = renderWithRouter(
+      <ConfigureEventTrigger workflowRef={WORKFLOW_REF} closeModal={() => {}} />,
+    );
+
+    // The displayed snippet appends &access_token=TOKEN — the URL parameter AuthenticationFilter accepts.
+    expect(container.textContent).toContain(
+      `${serviceUrl.resourceTrigger()}/event?ref=${WORKFLOW_REF}&access_token=TOKEN`,
+    );
+    expect(container.textContent).not.toContain(`event?workflow=`);
+
+    // The copy button hands the same ?ref= URL to the clipboard.
+    await userEvent.click(screen.getByRole("button", { name: /copy url/i }));
+    expect(copy).toHaveBeenCalledWith(`${serviceUrl.resourceTrigger()}/event?ref=${WORKFLOW_REF}`);
+  });
+});


### PR DESCRIPTION
**Bug.** The workflow editor rendered copyable webhook and event trigger URLs with a `?workflow=` query parameter, but the API only reads `?ref=` (`service-core/src/main/java/io/boomerang/event/WebhookEventControllerV2.java:82-87` for `POST /webhook`, `:216-222` for `POST /event`), so pasting the displayed URL returned a 400.

**Fix.** The URL correction itself already landed on `feat-v5` in 1ca21efbc (via #406):
- `client-web/src/Features/WorkflowEditor/Configure/BuildWebhookModalContent/BuildWebhookModalContent.tsx:16,40` — `?workflow=` → `?ref=`
- `client-web/src/Features/WorkflowEditor/Configure/ConfigureEventTrigger/ConfigureEventTrigger.tsx:31,52` — `?workflow=` → `?ref=`

This PR adds the missing regression coverage pinning that contract. The `&access_token=` URL parameter both modals show alongside is verified against what `AuthenticationFilter` accepts (restored in 4401fdaab).

**Test.** Two new vitest specs render each modal and assert the displayed snippet and the copied URL carry `?ref=<workflowRef>` and never `?workflow=`:
- `client-web/src/Features/WorkflowEditor/Configure/BuildWebhookModalContent/BuildWebhookModalContent.spec.tsx`
- `client-web/src/Features/WorkflowEditor/Configure/ConfigureEventTrigger/ConfigureEventTrigger.spec.tsx`

`vitest run` on the two specs: 2 passed; the full client-web suite: 74 files / 354 tests passed.

Fixes #385