### PR TITLE
fix(client-web): schedule labels render and label filters use the API's key=value form (#387)

### DIFF
--- a/client-web/src/ApiServer/fixtures/workflowSchedules.js
+++ b/client-web/src/ApiServer/fixtures/workflowSchedules.js
@@ -4,10 +4,7 @@ content: [
     dateSchedule: "2023-05-07T12:00:00",
     description: "Yep",
     id: "61d6286bc570b75ec2b47884",
-    labels: [
-      { key: "maintenance", value: "hello" },
-      { key: "daily", value: "yes" },
-    ],
+    labels: { maintenance: "hello", daily: "yes" },
     name: "Trigger",
     parameters: { name: "Tyson", word: "this" },
     status: "active",
@@ -17,10 +14,7 @@ content: [
     cronSchedule: "0 18 * * *",
     description: "This does stuff daily",
     id: "71d6286bc570b75ec2b47884",
-    labels: [
-      { key: "maintenance", value: "hello" },
-      { key: "daily", value: "yes" },
-    ],
+    labels: { maintenance: "hello", daily: "yes" },
     name: "Daily event",
     parameters: { name: "Tyson", word: "this" },
     status: "inactive",
@@ -31,10 +25,7 @@ content: [
     description:
       "This does stuff daily. But I need to include way to much information here. Way way too much, I mean it is absurd how much I am going to include here.",
     id: "81d6286bc570b75ec2b47884",
-    labels: [
-      { key: "maintenance", value: "hello" },
-      { key: "daily", value: "yes" },
-    ],
+    labels: { maintenance: "hello", daily: "yes" },
     name: "Deleted Daily event",
     parameters: { name: "Tyson", word: "this" },
     status: "deleted",

--- a/client-web/src/Components/SchedulePanelDetail/SchedulePanelDetail.spec.tsx
+++ b/client-web/src/Components/SchedulePanelDetail/SchedulePanelDetail.spec.tsx
@@ -1,0 +1,41 @@
+import { screen } from "@testing-library/react";
+import type { ScheduleUnion } from "Types";
+import { renderWithContext } from "Utils/testing/render";
+import SchedulePanelDetail from "./SchedulePanelDetail";
+
+const schedule: ScheduleUnion = {
+  id: "1",
+  name: "Nightly Backup",
+  description: "Backs up nightly",
+  status: "active",
+  type: "cron",
+  cronSchedule: "0 0 * * *",
+  timezone: "UTC",
+  workflowRef: "wf-1",
+  nextScheduleDate: "2026-08-25T00:00:00Z",
+  labels: { maintenance: "hello", daily: "yes" },
+};
+
+function renderDetail(event: ScheduleUnion) {
+  return renderWithContext(
+    <SchedulePanelDetail className="" event={event} isOpen setIsOpen={() => {}} setIsEditorOpen={() => {}} />,
+  );
+}
+
+describe("SchedulePanelDetail", () => {
+  // Regression (#387): the label rendering was commented out behind a TODO, so labels always
+  // showed as "---" even on schedules that had them. Labels arrive as a string map (backend
+  // WorkflowSchedule.labels is a Map<String,String>) and each entry renders as a key=value tag.
+  test("renders each label as a key=value tag", () => {
+    renderDetail(schedule);
+    expect(screen.getByText("maintenance=hello")).toBeInTheDocument();
+    expect(screen.getByText("daily=yes")).toBeInTheDocument();
+  });
+
+  test("falls back to --- when the schedule has no labels", () => {
+    renderDetail({ ...schedule, labels: undefined });
+    expect(screen.getByText("Labels")).toBeInTheDocument();
+    expect(screen.queryByText(/=/)).not.toBeInTheDocument();
+    expect(screen.getAllByText("---").length).toBeGreaterThan(0);
+  });
+});

--- a/client-web/src/Components/SchedulePanelList/SchedulePanelList.spec.tsx
+++ b/client-web/src/Components/SchedulePanelList/SchedulePanelList.spec.tsx
@@ -23,6 +23,7 @@ function buildSchedulesData(): PaginatedSchedulesResponse {
         timezone: "UTC",
         workflowRef: "wf-1",
         nextScheduleDate: "2026-08-25T00:00:00Z",
+        labels: { level: "important" },
       },
       {
         id: "2",
@@ -95,6 +96,26 @@ describe("SchedulePanelList", () => {
     renderList({ includeStatusFilter: false });
 
     await userEvent.type(screen.getByPlaceholderText("Search Schedules"), "Nightly");
+
+    expect(await screen.findByText("Nightly Backup")).toBeInTheDocument();
+    expect(screen.queryByText("One-off Migration")).not.toBeInTheDocument();
+  });
+
+  // Regression (#387): labels arrive as a string map (backend WorkflowSchedule.labels is a
+  // Map<String,String>), and each entry renders as a key=value tag - the old rendering assumed
+  // the retired [{key, value}] array shape and showed nothing.
+  test("renders a schedule's labels as key=value tags", () => {
+    renderList({ includeStatusFilter: false });
+    expect(screen.getByText("level=important")).toBeInTheDocument();
+  });
+
+  // Regression (#387): the fuzzy-search keys used to be "labels.0.key"/"labels.0.value" (array
+  // shape), so searching by label never matched; they now iterate the map entries in the same
+  // key=value form the tags render.
+  test("searching by a label's key=value form filters the list", async () => {
+    renderList({ includeStatusFilter: false });
+
+    await userEvent.type(screen.getByPlaceholderText("Search Schedules"), "level=important");
 
     expect(await screen.findByText("Nightly Backup")).toBeInTheDocument();
     expect(screen.queryByText("One-off Migration")).not.toBeInTheDocument();

--- a/client-web/src/Features/Schedules/Schedules.spec.tsx
+++ b/client-web/src/Features/Schedules/Schedules.spec.tsx
@@ -48,6 +48,16 @@ describe("Schedules --- loader", () => {
     expect(screen.getByText("Daily event")).toBeInTheDocument();
   });
 
+  // Regression (#387): the API serialises schedule labels as a string map (backend
+  // WorkflowSchedule.labels is a Map<String,String>); the fixture used to carry the retired
+  // [{key, value}] array shape, which Object.entries renders as "0=[object Object]". This pins
+  // the wire shape end to end: MSW response -> loader -> SchedulePanelList tags.
+  test("renders schedule labels from the API's string-map wire shape", async () => {
+    renderSchedules();
+    expect((await screen.findAllByText("maintenance=hello")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("daily=yes").length).toBeGreaterThan(0);
+  });
+
   // ScheduleStatus gained "completed" (a runOnce schedule moves there once it fires) - the
   // default (no filter selected) status list needs to keep including it, otherwise completed
   // schedules would silently vanish from the page on first load. See scheduleStatusOptions in


### PR DESCRIPTION
Fixes #387

## What

Closes out the schedule-labels defect. The render and search halves landed in f74ba889d (detail panel renders each `key=value` label; the list's fuzzy-search keys iterate the label map entries), but two pieces of residue kept the issue open:

- `client-web/src/ApiServer/fixtures/workflowSchedules.js` still carried labels in the retired `[{key, value}]` array shape. The API serialises `WorkflowSchedule.labels` as a string map (`Map<String, String>` on the backend model, verified against `WorkspaceScheduleControllerV2`/`lib-common`), so every MSW-driven spec was exercising a wire shape the product never sends - `Object.entries` over it renders `0=[object Object]`.
- Neither half was pinned by test.

## Changes

- Fixture labels converted to the `Record<string, string>` wire form.
- `SchedulePanelDetail.spec.tsx` (new): each label renders as a `key=value` tag; `---` fallback when a schedule has no labels.
- `SchedulePanelList.spec.tsx`: labels render as `key=value` tags; searching by the `key=value` form filters the list (regression pin for the old `labels.0.key`/`labels.0.value` array-shaped keys).
- `Schedules.spec.tsx`: end-to-end MSW response -> route loader -> list tags on the string-map shape.

Frontend only - no backend or wire changes. The schedule `/query` endpoint takes no `labels` request param (statuses/types/workflows only), so the list search stays client-side; the `key=value` search form matches the API's label convention (`WorkspaceWorkflowControllerV2`'s url-encoded `key=value` labels list).

## Verify

`cd client-web && pnpm exec vitest run src/Components/SchedulePanelDetail/SchedulePanelDetail.spec.tsx src/Components/SchedulePanelList/SchedulePanelList.spec.tsx src/Features/Schedules/Schedules.spec.tsx src/Features/Schedules/scheduleRoute.spec.ts src/Features/WorkflowEditor/Schedule/Schedule.spec.tsx`

5 files, 32 tests, all green. Full suite: 349 passed, 8 snapshot failures pre-existing on the untouched base (Users/Workspaces/WorkflowRun/ChangeLog date-drift snapshots, reproduced with this change stashed - unrelated to schedules).