### PR TITLE
fix(client-web): workspace search sends its term (#386)

### DIFF
--- a/client-web/src/ApiServer/msw/handlers.ts
+++ b/client-web/src/ApiServer/msw/handlers.ts
@@ -347,8 +347,20 @@ export const handlers: HttpHandler[] = [
   // getWorkspaces (the literal /workspace/query list route) must be registered before
   // resourceWorkspace's GET (the parameterized /workspace/:workspace below) - see the ordering
   // note on task.queryTasks above. Workspaces.tsx's table reads `number`/`size`/`totalElements`
-  // off this response, not just `content` (same reasoning as getUsers below).
-  http.get(serviceUrl.getWorkspaces({ query: "" }), () => HttpResponse.json(paginatedResponse(db.workspaces))),
+  // off this response, not just `content` (same reasoning as getUsers below). `search` mirrors
+  // WorkspaceService.findByCriteria: an anchored, case-insensitive prefix match on
+  // name/displayName (issue #386 - the loader forwards the search box's term as `search`).
+  http.get(serviceUrl.getWorkspaces({ query: "" }), ({ request }) => {
+    const search = new URL(request.url).searchParams.get("search")?.trim().toLowerCase();
+    const content = search
+      ? db.workspaces.filter(
+          (workspace) =>
+            workspace.name?.toLowerCase().startsWith(search) ||
+            workspace.displayName?.toLowerCase().startsWith(search),
+        )
+      : db.workspaces;
+    return HttpResponse.json(paginatedResponse(content));
+  }),
   http.get(serviceUrl.resourceWorkspace({ workspace: ":workspace" }), ({ params }) => {
     const workspace = findWorkspace(pathParam(params.workspace));
     return workspace ? HttpResponse.json(workspace) : HttpResponse.json({ errors: ["Workspace not found"] }, { status: 404 });

--- a/client-web/src/Features/Workspaces/Workspaces.spec.tsx
+++ b/client-web/src/Features/Workspaces/Workspaces.spec.tsx
@@ -1,17 +1,24 @@
 import React from "react";
 import Workspaces, { action, loader } from "Features/Workspaces/Workspaces";
 import { Route } from "react-router-dom";
-import { screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { AppPath, appLink } from "Config/appConfig";
 import { renderWithContext } from "Utils/testing/render";
+
+// setupTests.tsx freezes the wall clock via `vi.setSystemTime` (no fake timers), and lodash's
+// debounce decides whether to invoke by comparing `Date.now()` deltas - with time frozen its
+// trailing-edge timer re-schedules forever and the callback never runs. Neutralise the debounce
+// (invoke immediately) so the typed-search test below can exercise the real
+// change -> navigate -> loader -> API chain.
+vi.mock("lodash/debounce", () => ({ default: (fn: (...args: unknown[]) => void) => fn }));
 
 // Route-module test pattern (see GlobalParameters.spec.tsx): attach loader/action to the <Route>
 // the same way AppRoutes.tsx does via app/routes/workspaceList.tsx, so renderWithContext
 // actually exercises them instead of leaving useLoaderData() undefined.
-function renderWorkspaces() {
+function renderWorkspaces(route: string = appLink.workspaceList()) {
   return renderWithContext(
     <Route path={AppPath.WorkspaceList} loader={loader} action={action} element={<Workspaces />} />,
-    { route: appLink.workspaceList() },
+    { route },
   );
 }
 
@@ -20,6 +27,29 @@ describe("Workspaces --- Snapshot Test", () => {
     const { baseElement } = renderWorkspaces();
     await screen.findByText("Tyson Workspace");
     expect(baseElement).toMatchSnapshot();
+  });
+});
+
+// Regression for #386: the search box's debounced `query` URL param must reach the API as
+// `search=` (the loader forwards it; the MSW /workspace/query handler mirrors the backend's
+// anchored, case-insensitive prefix match on name/displayName).
+describe("Workspaces --- search sends its term (#386)", () => {
+  test("a direct load of ?query= filters the list server-side and seeds the search box", async () => {
+    renderWorkspaces(`${appLink.workspaceList()}?query=system`);
+    expect(await screen.findByText("System and Administration")).toBeInTheDocument();
+    expect(screen.queryByText("Tyson Workspace")).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Search workspaces")).toHaveValue("system");
+  });
+
+  test("typing in the search box filters the list server-side", async () => {
+    renderWorkspaces();
+    await screen.findByText("Tyson Workspace");
+    fireEvent.change(screen.getByPlaceholderText("Search workspaces"), { target: { value: "system" } });
+    // The (neutralised, see the lodash/debounce mock above) search change navigates to
+    // ?query=system, which re-runs the loader with search= - the unfiltered list shows every
+    // workspace, so the meaningful signal is the non-matching rows disappearing.
+    await waitFor(() => expect(screen.queryByText("Tyson Workspace")).not.toBeInTheDocument());
+    expect(screen.getByText("System and Administration")).toBeInTheDocument();
   });
 });
 

--- a/client-web/src/Features/Workspaces/Workspaces.tsx
+++ b/client-web/src/Features/Workspaces/Workspaces.tsx
@@ -35,10 +35,11 @@ import { actionError, isActionError, type ActionError } from "Utils/actionResult
 
 interface FeatureLayoutProps {
   children?: React.ReactNode;
+  defaultQuery?: string;
   handleSearchChange: (e: { target: HTMLInputElement; type: "change" }) => void;
 }
 
-const FeatureLayout: React.FC<FeatureLayoutProps> = ({ children, handleSearchChange }) => {
+const FeatureLayout: React.FC<FeatureLayoutProps> = ({ children, defaultQuery, handleSearchChange }) => {
   return (
     <>
       <Helmet>
@@ -56,7 +57,13 @@ const FeatureLayout: React.FC<FeatureLayoutProps> = ({ children, handleSearchCha
       <Box p="2rem" className={styles.content}>
         <>
           <Box mb="1rem" maxWidth="20rem">
-            <Search id="flow-workspaces" labelText="Search workspaces" placeholder="Search workspaces" onChange={handleSearchChange} />
+            <Search
+              id="flow-workspaces"
+              labelText="Search workspaces"
+              placeholder="Search workspaces"
+              defaultValue={defaultQuery}
+              onChange={handleSearchChange}
+            />
           </Box>
           {children}
         </>
@@ -143,6 +150,9 @@ const WorkspaceList: React.FC = () => {
   const parsedQuery = queryString.parse(location.search, queryStringOptions);
   const order = typeof parsedQuery.order === "string" ? parsedQuery.order : DEFAULT_ORDER;
   const sort = typeof parsedQuery.sort === "string" ? parsedQuery.sort : DEFAULT_SORT;
+  // Seed the (uncontrolled) search box with the URL's term so a direct/SSR load of
+  // `?query=...` shows the term the list is already filtered by (#386).
+  const query = typeof parsedQuery.query === "string" ? parsedQuery.query : undefined;
 
   useEffect(() => {
     if (fetcher.state !== "idle" || !fetcher.data) {
@@ -228,13 +238,13 @@ const WorkspaceList: React.FC = () => {
 
   if (errorLoading || !workspacesData) {
     return (
-      <FeatureLayout handleSearchChange={handleSearchChange}>
+      <FeatureLayout defaultQuery={query} handleSearchChange={handleSearchChange}>
         <ErrorMessage />
       </FeatureLayout>
     );
   }
   return (
-    <FeatureLayout handleSearchChange={handleSearchChange}>
+    <FeatureLayout defaultQuery={query} handleSearchChange={handleSearchChange}>
       {workspaceManagementEnabled && (
         <ComposedModal
           composedModalProps={{ shouldCloseOnOverlayClick: true }}


### PR DESCRIPTION
Fixes #386

**What.** The Workspaces search box's term now demonstrably reaches the API. The loader-side forwarding (`query` URL param -> `search=`) landed in 9f12e208a on `feat-v5` after the issue was filed; this PR completes the issue with regression coverage and the residual gaps around it. Backend needed no changes - `WorkspaceControllerV2` / `WorkspaceService.findByCriteria` already implement `search` (anchored, case-insensitive prefix match on `name`/`displayName`), verified in place.

**Changes.**
- `client-web/src/Features/Workspaces/Workspaces.spec.tsx` - two regression tests: a direct load of `?query=` filters the list server-side (and seeds the search box), and typing in the search box navigates and re-filters.
- `client-web/src/ApiServer/msw/handlers.ts` - the `/workspace/query` handler now honours `search=` with the same prefix-match semantics as the backend, so the tests observe the term actually reaching the API instead of an always-full list.
- `client-web/src/Features/Workspaces/Workspaces.tsx` - the uncontrolled search box is seeded from the URL's `query` param, so a direct/SSR load of `?query=` shows the term the list is already filtered by.

**Test-only note.** `setupTests.tsx` freezes the clock via `vi.setSystemTime` (no fake timers), and lodash `debounce` decides invocation off `Date.now()` deltas - with time frozen its trailing-edge timer re-schedules forever and the debounced navigate never fires under vitest (it is fine at runtime). The spec neutralises `lodash/debounce` to invoke immediately.

**Verification.** `vitest run src/Features/Workspaces/Workspaces.spec.tsx src/ApiServer/msw/handlers.spec.ts`: 2 files, 13 tests, all passing (snapshot unchanged).
