### PR TITLE
test: pin v5 behaviour for the v4-era reports (#239 #241 #244 #250)

### DIFF
--- a/service-core/src/test/java/io/boomerang/workflow/CanvasNodesUniquePerTaskTest.java
+++ b/service-core/src/test/java/io/boomerang/workflow/CanvasNodesUniquePerTaskTest.java
@@ -1,0 +1,65 @@
+package io.boomerang.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.boomerang.common.enums.TaskType;
+import io.boomerang.common.model.Workflow;
+import io.boomerang.common.model.WorkflowTask;
+import io.boomerang.common.model.WorkflowTaskDependency;
+import io.boomerang.engine.AbstractEngineIntegrationTest;
+import io.boomerang.workflow.model.WorkflowCanvas;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * boomerang-io/flow#239: the v4 Workflow Revision API duplicated every record in
+ * .config.nodes[]. v5 has no stored config.nodes at all - the canvas nodes are derived
+ * 1:1 from the revision's tasks by WorkflowService.convertWorkflowToCanvas. This pins
+ * that a workflow with N tasks composes to exactly N canvas nodes with unique names.
+ */
+class CanvasNodesUniquePerTaskTest extends AbstractEngineIntegrationTest {
+
+  @Autowired private WorkflowService workflowService;
+
+  @Test
+  void composeProducesExactlyOneNodePerTask() {
+    Workflow workflow = new Workflow();
+    workflow.setName("canvas-unique-nodes");
+    workflow.setTasks(
+        new LinkedList<>(
+            List.of(
+                task("start", TaskType.start, null),
+                task("hello", TaskType.template, "start"),
+                task("world", TaskType.template, "hello"),
+                task("end", TaskType.end, "world"))));
+
+    WorkflowCanvas canvas = workflowService.convertWorkflowToCanvas(workflow);
+
+    assertEquals(4, canvas.getNodes().size(), "one canvas node per task - no duplicates");
+    Set<String> names =
+        canvas.getNodes().stream().map(n -> n.getData().getName()).collect(Collectors.toSet());
+    assertEquals(
+        Set.of("start", "hello", "world", "end"),
+        names,
+        "every task appears exactly once in .nodes[]");
+    assertEquals(
+        3, canvas.getEdges().size(), "one edge per declared dependency, none duplicated");
+  }
+
+  private static WorkflowTask task(String name, TaskType type, String dependsOn) {
+    WorkflowTask task = new WorkflowTask();
+    task.setName(name);
+    task.setType(type);
+    task.setTaskRef(name);
+    if (dependsOn != null) {
+      WorkflowTaskDependency dependency = new WorkflowTaskDependency();
+      dependency.setTaskRef(dependsOn);
+      task.setDependencies(new LinkedList<>(List.of(dependency)));
+    }
+    return task;
+  }
+}

--- a/service-core/src/test/java/io/boomerang/workflow/TriggerAgnosticWorkspacesTest.java
+++ b/service-core/src/test/java/io/boomerang/workflow/TriggerAgnosticWorkspacesTest.java
@@ -1,0 +1,85 @@
+package io.boomerang.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.boomerang.common.entity.WorkflowRunEntity;
+import io.boomerang.common.enums.TaskType;
+import io.boomerang.common.enums.TriggerEnum;
+import io.boomerang.common.model.Task;
+import io.boomerang.common.model.Workflow;
+import io.boomerang.common.model.WorkflowSubmitRequest;
+import io.boomerang.common.model.WorkflowTask;
+import io.boomerang.common.model.WorkflowTaskDependency;
+import io.boomerang.common.model.WorkflowWorkspace;
+import io.boomerang.engine.AbstractEngineIntegrationTest;
+import java.util.LinkedList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * boomerang-io/flow#250: in v4, webhook-triggered runs lost their workspace PV while manual
+ * runs mounted it. v5 has a single submit path (WorkflowService.internalSubmit) that copies
+ * the revision's workspaces onto the WorkflowRun identically for every trigger. This pins
+ * that a manual and a webhook submit of the same workflow produce runs with identical
+ * workspace sets.
+ */
+class TriggerAgnosticWorkspacesTest extends AbstractEngineIntegrationTest {
+
+  @Autowired private WorkflowService workflowService;
+
+  @Test
+  void webhookAndManualSubmitsCarryIdenticalWorkspaces() {
+    Task template = new Task();
+    template.setName("trigger-ws-echo");
+    template.setType(TaskType.template);
+    template.getSpec().setImage("busybox:latest");
+    template.getSpec().setCommand(List.of("echo"));
+    String templateId = taskService.create(template).getId();
+
+    Workflow workflow = new Workflow();
+    workflow.setName("trigger-agnostic-workspaces");
+    workflow.getTriggers().getWebhook().setEnabled(true);
+    workflow.setTasks(
+        new LinkedList<>(
+            List.of(
+                task("start", TaskType.start, null, null),
+                task("work", TaskType.template, templateId, "start"),
+                task("end", TaskType.end, null, "work"))));
+    WorkflowWorkspace ws = new WorkflowWorkspace();
+    ws.setName("run-store");
+    ws.setType("workflowrun");
+    workflow.setWorkspaces(new LinkedList<>(List.of(ws)));
+    String workflowId = workflowService.create(workflow, false).getBody().getId();
+
+    WorkflowSubmitRequest manual = new WorkflowSubmitRequest();
+    manual.setTrigger(TriggerEnum.manual);
+    String manualRunId = workflowService.submit(workflowId, manual, false).getId();
+
+    WorkflowSubmitRequest webhook = new WorkflowSubmitRequest();
+    webhook.setTrigger(TriggerEnum.webhook);
+    String webhookRunId = workflowService.submit(workflowId, webhook, false).getId();
+
+    WorkflowRunEntity manualRun = workflowRunRepository.findById(manualRunId).orElseThrow();
+    WorkflowRunEntity webhookRun = workflowRunRepository.findById(webhookRunId).orElseThrow();
+
+    assertEquals(1, manualRun.getWorkspaces().size());
+    assertEquals(
+        manualRun.getWorkspaces(),
+        webhookRun.getWorkspaces(),
+        "the webhook-triggered run must carry exactly the workspaces the manual run does");
+  }
+
+  private static WorkflowTask task(String name, TaskType type, String taskRef, String dependsOn) {
+    WorkflowTask task = new WorkflowTask();
+    task.setName(name);
+    task.setType(type);
+    task.setTaskRef(taskRef);
+    if (dependsOn != null) {
+      WorkflowTaskDependency dependency = new WorkflowTaskDependency();
+      dependency.setTaskRef(dependsOn);
+      task.setDependencies(new LinkedList<>(List.of(dependency)));
+    }
+    return task;
+  }
+}


### PR DESCRIPTION
Triage of four v4-era bug reports against the v5 code. Two of them are fixed by the v5 rewrite; this PR commits the passing pin tests so the fixed behaviour stays fixed.

- `CanvasNodesUniquePerTaskTest` (#239): the v4 revision entity stored `config.nodes` alongside `dag.tasks` and the GET merged both, duplicating every node. The v5 `WorkflowRevisionEntity` has no `config` at all - canvas nodes are derived 1:1 from the revision tasks in `WorkflowService.convertWorkflowToCanvas`. The test pins one node per task, unique names, one edge per dependency.
- `TriggerAgnosticWorkspacesTest` (#250): v4 webhook-triggered runs lost their workspace PV while manual runs mounted it. v5 has a single submit path (`WorkflowService.internalSubmit`) that copies the revision workspaces onto the run identically for every trigger. The test pins that a manual and a webhook submit of the same workflow carry identical workspace sets.

#241 still reproduces (duplicate result keys - evidence on the issue; the failing test is deliberately not committed) and the `ControllerClientImpl.submitCustomTask` that #244 questions no longer exists.

Both tests run green via `mvn -pl service-core -am test`.
