### PR TITLE
fix(quota): run quotas enforce under simultaneous submits

### DIFF
--- a/service-core/src/main/java/io/boomerang/workflow/WorkflowRunService.java
+++ b/service-core/src/main/java/io/boomerang/workflow/WorkflowRunService.java
@@ -240,6 +240,37 @@ public class WorkflowRunService {
     return count(from.map(Date::new), to.map(Date::new), queryLabels, Optional.of(wfRefs));
   }
 
+  /**
+   * Count runs matching the given Workflows with a single server-side count - no documents are
+   * fetched and nothing is grouped in memory. Serves the quota counters in {@code
+   * WorkspaceService.setCurrentQuotas}: the monthly counter passes the calendar-month {@code
+   * creationDate} window with no statuses, the concurrent counter passes the non-terminal statuses
+   * with no window.
+   */
+  public long countForQuota(
+      List<String> workflowRefs,
+      Optional<Date> from,
+      Optional<Date> to,
+      Optional<Set<RunStatus>> statuses) {
+    List<Criteria> criteriaList = new ArrayList<>();
+    criteriaList.add(Criteria.where("workflowRef").in(workflowRefs));
+    if (from.isPresent() && !to.isPresent()) {
+      criteriaList.add(Criteria.where("creationDate").gte(from.get()));
+    } else if (!from.isPresent() && to.isPresent()) {
+      criteriaList.add(Criteria.where("creationDate").lt(to.get()));
+    } else if (from.isPresent() && to.isPresent()) {
+      criteriaList.add(Criteria.where("creationDate").gte(from.get()).lt(to.get()));
+    }
+    if (statuses.isPresent()) {
+      criteriaList.add(Criteria.where("status").in(statuses.get()));
+    }
+    Query query =
+        new Query(
+            new Criteria().andOperator(criteriaList.toArray(new Criteria[criteriaList.size()])));
+    LOGGER.debug("Quota count query: {}", query);
+    return mongoTemplate.count(query, WorkflowRunEntity.class);
+  }
+
   /*
    * Start WorkflowRun
    *

--- a/service-core/src/main/java/io/boomerang/workflow/WorkflowService.java
+++ b/service-core/src/main/java/io/boomerang/workflow/WorkflowService.java
@@ -10,6 +10,7 @@ import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import io.boomerang.common.entity.TaskRevisionEntity;
+import io.boomerang.common.entity.TaskRunEntity;
 import io.boomerang.common.entity.WorkflowEntity;
 import io.boomerang.common.entity.WorkflowRevisionEntity;
 import io.boomerang.common.entity.WorkflowRunEntity;
@@ -673,7 +674,14 @@ public class WorkflowService {
     executionAnnotations.put("boomerang.io/workspace-name", team);
     request.getAnnotations().putAll(executionAnnotations);
 
-    WorkflowRun wfRun = submit(workflowId, request, start, initiatedByRef);
+    // Admit-then-recheck: with quotas enforced the run is created un-started, the quota counts
+    // are re-read (now including this run), and a run that pushed a count over its limit is
+    // discarded - simultaneous submits cannot each slip past the pre-admission count above.
+    boolean enforceQuotas = quotasEnforced();
+    WorkflowRun wfRun = submit(workflowId, request, start && !enforceQuotas, initiatedByRef);
+    if (enforceQuotas) {
+      guardQuotasAfterAdmission(team, wfRun.getId());
+    }
 
     // Creates relationship with owning team
     // TODO: create this run relationship based on decision of team vs workflow
@@ -686,6 +694,13 @@ public class WorkflowService {
         wfRun.getId(),
         Optional.empty(),
         Optional.empty());
+    // A run with Workspaces stays ready/pending for the dispatcher to provision and start -
+    // the same rule WorkflowRunService.run applies on the un-enforced path.
+    if (enforceQuotas
+        && start
+        && (wfRun.getWorkspaces() == null || wfRun.getWorkspaces().isEmpty())) {
+      wfRun = workflowRunService.start(wfRun.getId(), Optional.empty());
+    }
     return wfRun;
   }
 
@@ -928,13 +943,15 @@ public class WorkflowService {
     if (quotasEnforced()) {
       CurrentQuotas quotas = workspaceService.getObject().getCurrentQuotas(team);
       LOGGER.debug("Quotas: {}", quotas.toString());
-      if (quotas.getCurrentConcurrentRuns() > quotas.getMaxConcurrentRuns()) {
+      // The run being submitted is not counted yet, so at-the-limit already means it would
+      // exceed the limit.
+      if (quotas.getCurrentConcurrentRuns() >= quotas.getMaxConcurrentRuns()) {
         throw new BoomerangException(
             BoomerangError.QUOTA_EXCEEDED,
             "Concurrent runs (executions)",
             quotas.getCurrentConcurrentRuns(),
             quotas.getMaxConcurrentRuns());
-      } else if (quotas.getCurrentRuns() > quotas.getMaxWorkflowRunMonthly()) {
+      } else if (quotas.getCurrentRuns() >= quotas.getMaxWorkflowRunMonthly()) {
         throw new BoomerangException(
             BoomerangError.QUOTA_EXCEEDED,
             "Number of runs (executions)",
@@ -979,6 +996,42 @@ public class WorkflowService {
                 });
       }
     }
+  }
+
+  /*
+   * Re-checks the run quotas after a WorkflowRun has been admitted. The counts now include the
+   * run itself, so a burst of simultaneous submits cannot each pass the pre-admission count:
+   * every run that pushed a count over its limit removes itself and its submit fails.
+   */
+  private void guardQuotasAfterAdmission(String team, String workflowRunId) {
+    CurrentQuotas quotas = workspaceService.getObject().getCurrentQuotas(team);
+    if (quotas.getCurrentConcurrentRuns() > quotas.getMaxConcurrentRuns()) {
+      discardRun(workflowRunId);
+      throw new BoomerangException(
+          BoomerangError.QUOTA_EXCEEDED,
+          "Concurrent runs (executions)",
+          quotas.getCurrentConcurrentRuns(),
+          quotas.getMaxConcurrentRuns());
+    } else if (quotas.getCurrentRuns() > quotas.getMaxWorkflowRunMonthly()) {
+      discardRun(workflowRunId);
+      throw new BoomerangException(
+          BoomerangError.QUOTA_EXCEEDED,
+          "Number of runs (executions)",
+          quotas.getCurrentRuns(),
+          quotas.getMaxWorkflowRunMonthly());
+    }
+  }
+
+  /*
+   * Removes a quota-rejected WorkflowRun and its materialised TaskRuns. The run was never
+   * started and no relationship edge exists yet, so removing the documents is the whole undo -
+   * and keeps a rejected submit from consuming quota itself.
+   */
+  private void discardRun(String workflowRunId) {
+    mongoTemplate.remove(
+        Query.query(Criteria.where("workflowRunRef").is(workflowRunId)), TaskRunEntity.class);
+    mongoTemplate.remove(
+        Query.query(Criteria.where("_id").is(workflowRunId)), WorkflowRunEntity.class);
   }
 
   /*

--- a/service-core/src/main/java/io/boomerang/workspace/WorkspaceService.java
+++ b/service-core/src/main/java/io/boomerang/workspace/WorkspaceService.java
@@ -2,9 +2,11 @@ package io.boomerang.workspace;
 
 import static io.boomerang.common.util.DataAdapterUtil.filterValueByFieldType;
 
+import io.boomerang.workflow.WorkflowRunService;
 import io.boomerang.workflow.WorkflowService;
 import io.boomerang.common.model.AbstractParam;
 import io.boomerang.common.model.WorkflowCount;
+import io.boomerang.common.enums.RunStatus;
 import io.boomerang.common.model.WorkflowRunInsight;
 import io.boomerang.common.util.DataAdapterUtil.FieldType;
 import io.boomerang.common.util.ParameterUtil;
@@ -95,6 +97,7 @@ public class WorkspaceService {
   private final MongoTemplate mongoTemplate;
   private final InsightsService insightsService;
   private final WorkflowService workflowService;
+  private final WorkflowRunService workflowRunService;
   private final TokenService tokenService;
   private final TaskService taskService;
 
@@ -109,6 +112,7 @@ public class WorkspaceService {
       MongoTemplate mongoTemplate,
       InsightsService insightsService,
       WorkflowService workflowService,
+      WorkflowRunService workflowRunService,
       TokenService tokenService,
       TaskService taskService) {
     this.workspaceRepository = workspaceRepository;
@@ -121,6 +125,7 @@ public class WorkspaceService {
     this.mongoTemplate = mongoTemplate;
     this.insightsService = insightsService;
     this.workflowService = workflowService;
+    this.workflowRunService = workflowRunService;
     this.tokenService = tokenService;
     this.taskService = taskService;
   }
@@ -1030,10 +1035,32 @@ public class WorkspaceService {
             Optional.empty(),
             Optional.empty());
     LOGGER.debug("Insights: {}", insight.toString());
-    currentQuotas.setCurrentConcurrentRuns(insight.getConcurrentRuns().intValue());
     currentQuotas.setCurrentRunTotalDuration(insight.getTotalDuration().intValue());
     currentQuotas.setCurrentRunMedianDuration(insight.getMedianDuration().intValue());
-    currentQuotas.setCurrentRuns(insight.getTotalRuns().intValue());
+
+    // The run counters that quotas enforce come from the live WorkflowRun collection - the
+    // audit-derived insight cannot serve them, as no workflowrun-scope audit record is written.
+    // Concurrent = admitted and not yet terminal, so queued work counts against the limit.
+    Map<String, Long> monthlyRuns =
+        workflowRunService
+            .count(
+                team,
+                Optional.of(currentMonthStart.getTimeInMillis()),
+                Optional.of(nextMonth.getTimeInMillis()),
+                Optional.empty(),
+                Optional.empty())
+            .getStatus();
+    currentQuotas.setCurrentRuns(monthlyRuns.get("all").intValue());
+    Map<String, Long> runsByStatus =
+        workflowRunService
+            .count(team, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+            .getStatus();
+    currentQuotas.setCurrentConcurrentRuns(
+        (int)
+            (runsByStatus.get(RunStatus.notstarted.getStatus())
+                + runsByStatus.get(RunStatus.ready.getStatus())
+                + runsByStatus.get(RunStatus.running.getStatus())
+                + runsByStatus.get(RunStatus.waiting.getStatus())));
 
     WorkflowCount count =
         workflowService.count(

--- a/service-core/src/main/java/io/boomerang/workspace/WorkspaceService.java
+++ b/service-core/src/main/java/io/boomerang/workspace/WorkspaceService.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -1041,26 +1042,32 @@ public class WorkspaceService {
     // The run counters that quotas enforce come from the live WorkflowRun collection - the
     // audit-derived insight cannot serve them, as no workflowrun-scope audit record is written.
     // Concurrent = admitted and not yet terminal, so queued work counts against the limit.
-    Map<String, Long> monthlyRuns =
-        workflowRunService
-            .count(
-                team,
-                Optional.of(currentMonthStart.getTimeInMillis()),
-                Optional.of(nextMonth.getTimeInMillis()),
-                Optional.empty(),
-                Optional.empty())
-            .getStatus();
-    currentQuotas.setCurrentRuns(monthlyRuns.get("all").intValue());
-    Map<String, Long> runsByStatus =
-        workflowRunService
-            .count(team, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
-            .getStatus();
+    List<String> workflowRefs =
+        relationshipService.filter(
+            RelationshipType.WORKFLOW,
+            Optional.empty(),
+            Optional.of(RelationshipType.WORKSPACE),
+            Optional.of(List.of(team)),
+            false);
+    currentQuotas.setCurrentRuns(
+        (int)
+            workflowRunService.countForQuota(
+                workflowRefs,
+                Optional.of(currentMonthStart.getTime()),
+                Optional.of(nextMonth.getTime()),
+                Optional.empty()));
     currentQuotas.setCurrentConcurrentRuns(
         (int)
-            (runsByStatus.get(RunStatus.notstarted.getStatus())
-                + runsByStatus.get(RunStatus.ready.getStatus())
-                + runsByStatus.get(RunStatus.running.getStatus())
-                + runsByStatus.get(RunStatus.waiting.getStatus())));
+            workflowRunService.countForQuota(
+                workflowRefs,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(
+                    Set.of(
+                        RunStatus.notstarted,
+                        RunStatus.ready,
+                        RunStatus.running,
+                        RunStatus.waiting))));
 
     WorkflowCount count =
         workflowService.count(

--- a/service-core/src/test/java/io/boomerang/workflow/StandaloneQuotaConcurrentSubmitTest.java
+++ b/service-core/src/test/java/io/boomerang/workflow/StandaloneQuotaConcurrentSubmitTest.java
@@ -1,0 +1,204 @@
+package io.boomerang.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.boomerang.common.entity.WorkflowRunEntity;
+import io.boomerang.common.enums.RunPhase;
+import io.boomerang.common.enums.TriggerEnum;
+import io.boomerang.common.error.BoomerangException;
+import io.boomerang.common.model.WorkflowSubmitRequest;
+import io.boomerang.core.security.enums.AuthScope;
+import io.boomerang.core.security.enums.PermissionScope;
+import io.boomerang.core.security.model.ResolvedPermissions;
+import io.boomerang.core.model.Token;
+import io.boomerang.engine.AbstractEngineIntegrationTest;
+import io.boomerang.workspace.WorkspaceService;
+import io.boomerang.workspace.model.Quotas;
+import io.boomerang.workspace.model.WorkspaceRequest;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * A burst of simultaneous submits must not admit more WorkflowRuns than the workspace quota
+ * allows (boomerang-io/flow#347): the quota check is a read-then-insert, so every racer can read
+ * a count below the limit and all of them pass. Each test fires one burst against a quota of one
+ * and asserts on the resulting WorkflowRun documents - the ground truth a racy check would
+ * over-populate.
+ */
+class StandaloneQuotaConcurrentSubmitTest extends AbstractEngineIntegrationTest {
+
+  private static final String QUOTA_FEATURE = "workspaceQuotas";
+
+  private static final String TASK_SLUG = "quota-burst-test-task";
+
+  private static final int BURST = 8;
+
+  @Autowired private WorkflowService workflowService;
+  @Autowired private WorkspaceService workspaceService;
+
+  @BeforeEach
+  void seedFixtures() {
+    seedRelationshipRoot();
+    seedTeamQuotaSettings();
+    seedTaskSettings();
+    seedGlobalTask(TASK_SLUG);
+    setFeatureSetting("globalParameters", false);
+    setFeatureSetting("workspaceParameters", false);
+    setFeatureSetting(QUOTA_FEATURE, false);
+  }
+
+  @AfterEach
+  void resetQuotaFeature() {
+    // Shared Testcontainers Mongo: leave the feature off, the state the other test classes seed.
+    setFeatureSetting(QUOTA_FEATURE, false);
+  }
+
+  @Test
+  void aSubmitBurstCannotExceedTheMonthlyRunQuota() throws Exception {
+    Quotas quotas = new Quotas();
+    quotas.setMaxWorkflowRunMonthly(1);
+    String workspace = createWorkspace("quota-burst-monthly", quotas);
+    String workflow = "quota-burst-monthly-workflow";
+    workflowService.create(workspace, runnableWorkflow(workflow, TASK_SLUG));
+    setFeatureSetting(QUOTA_FEATURE, true);
+
+    int admitted = submitBurst(workspace, workflow);
+
+    assertTrue(
+        admitted <= 1, "monthly quota of 1 admitted " + admitted + " of " + BURST + " submits");
+    // Simultaneous racers may all withdraw (each counted the others), leaving the slot free -
+    // the guarantee is that the limit is never over-filled. A follow-up submit fills exactly
+    // the remaining slot, and one more is refused.
+    if (admitted == 0) {
+      workflowService.submit(workspace, workflow, manualRequest(), false);
+    }
+    BoomerangException refused =
+        assertThrows(
+            BoomerangException.class,
+            () -> workflowService.submit(workspace, workflow, manualRequest(), false));
+    assertEquals("QUOTA_EXCEEDED", refused.getReason());
+    assertEquals(
+        1, persistedRuns(workspace, workflow), "WorkflowRun documents exceed the monthly quota");
+  }
+
+  @Test
+  void aSubmitBurstCannotExceedTheConcurrentRunQuota() throws Exception {
+    Quotas quotas = new Quotas();
+    quotas.setMaxConcurrentRuns(1);
+    String workspace = createWorkspace("quota-burst-concurrent", quotas);
+    String workflow = "quota-burst-concurrent-workflow";
+    workflowService.create(workspace, runnableWorkflow(workflow, TASK_SLUG));
+    setFeatureSetting(QUOTA_FEATURE, true);
+
+    int admitted = submitBurst(workspace, workflow);
+
+    // Nothing here starts or finishes a run, so every admitted run is still in flight: the
+    // number admitted is the concurrency the quota allowed.
+    assertTrue(
+        admitted <= 1, "concurrent quota of 1 admitted " + admitted + " of " + BURST + " submits");
+    if (admitted == 0) {
+      workflowService.submit(workspace, workflow, manualRequest(), false);
+    }
+    BoomerangException refused =
+        assertThrows(
+            BoomerangException.class,
+            () -> workflowService.submit(workspace, workflow, manualRequest(), false));
+    assertEquals("QUOTA_EXCEEDED", refused.getReason());
+    assertEquals(
+        1,
+        persistedRuns(workspace, workflow),
+        "WorkflowRun documents exceed the concurrent quota");
+  }
+
+  /**
+   * Fires {@code BURST} submits released together and returns how many were admitted. A rejection
+   * counts only when it is the quota refusing (QUOTA_EXCEEDED); any other failure propagates.
+   */
+  private int submitBurst(String workspace, String workflow) throws Exception {
+    ExecutorService pool = Executors.newFixedThreadPool(BURST);
+    CountDownLatch release = new CountDownLatch(1);
+    AtomicInteger admitted = new AtomicInteger();
+    try {
+      List<Future<?>> submits =
+          java.util.stream.IntStream.range(0, BURST)
+              .<Future<?>>mapToObj(
+                  i ->
+                      pool.submit(
+                          () -> {
+                            establishThreadIdentity();
+                            release.await();
+                            try {
+                              workflowService.submit(workspace, workflow, manualRequest(), false);
+                              admitted.incrementAndGet();
+                            } catch (BoomerangException e) {
+                              assertEquals("QUOTA_EXCEEDED", e.getReason());
+                            } finally {
+                              SecurityContextHolder.clearContext();
+                            }
+                            return null;
+                          }))
+              .toList();
+      release.countDown();
+      for (Future<?> submit : submits) {
+        submit.get(60, TimeUnit.SECONDS);
+      }
+    } finally {
+      pool.shutdownNow();
+    }
+    return admitted.get();
+  }
+
+  private static WorkflowSubmitRequest manualRequest() {
+    WorkflowSubmitRequest request = new WorkflowSubmitRequest();
+    request.setTrigger(TriggerEnum.manual);
+    return request;
+  }
+
+  /** SecurityContextHolder is thread-local, so each burst thread carries its own identity. */
+  private static void establishThreadIdentity() {
+    Token principal = new Token(AuthScope.global);
+    principal.setPrincipal("quota-burst-principal");
+    principal.setPermissions(
+        List.of(new ResolvedPermissions(PermissionScope.global, "**", List.of("**/**"))));
+    UsernamePasswordAuthenticationToken authentication =
+        new UsernamePasswordAuthenticationToken(principal.getPrincipal(), null);
+    authentication.setDetails(principal);
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+  }
+
+  private long persistedRuns(String workspace, String workflow) {
+    List<String> refs =
+        relationshipService.filter(
+            io.boomerang.core.enums.RelationshipType.WORKFLOW,
+            java.util.Optional.of(List.of(workflow)),
+            java.util.Optional.of(io.boomerang.core.enums.RelationshipType.WORKSPACE),
+            java.util.Optional.of(List.of(workspace)),
+            false);
+    assertEquals(1, refs.size(), "expected exactly one workflow ref for " + workflow);
+    List<WorkflowRunEntity> runs =
+        workflowRunRepository.findByWorkflowRefAndPhaseIn(
+            refs.get(0), List.of(RunPhase.values()));
+    return runs.size();
+  }
+
+  private String createWorkspace(String name, Quotas quotas) {
+    WorkspaceRequest request = new WorkspaceRequest();
+    request.setName(name);
+    request.setDisplayName(name);
+    request.setQuotas(quotas);
+    return workspaceService.create(request).getName();
+  }
+}

--- a/service-loader/src/main/java/io/boomerang/loader/migration/_0041__QuotaCountIndexes.java
+++ b/service-loader/src/main/java/io/boomerang/loader/migration/_0041__QuotaCountIndexes.java
@@ -1,0 +1,63 @@
+package io.boomerang.loader.migration;
+
+import static io.boomerang.loader.migration.MigrationUtils.dropIndex;
+import static io.boomerang.loader.migration.MigrationUtils.ensureIndexKeys;
+
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
+import io.boomerang.loader.CollectionNames;
+import io.flamingock.api.annotations.Apply;
+import io.flamingock.api.annotations.Change;
+import io.flamingock.api.annotations.Rollback;
+import io.flamingock.api.annotations.TargetSystem;
+import org.bson.Document;
+
+/**
+ * The {@code workflow_runs} indexes behind the quota counters. Every quota evaluation ({@code
+ * WorkspaceService.setCurrentQuotas}) issues two server-side counts via {@code
+ * WorkflowRunService.countForQuota}, both anchored on {@code workflowRef $in} - a predicate no
+ * existing index leads with ({@code _0017__RunIndexes}' {@code claim_page} leads with {@code
+ * status}; {@code _0037__SweepIndexes}' {@code workflow_ref_phase} covers {@code workflowRef} but
+ * pairs it with {@code phase}, which neither count filters beyond the prefix).
+ *
+ * <p>Both non-unique, and both created via {@link MigrationUtils#ensureIndexKeys} for the same
+ * reason as {@code _0036}: a v4 install ran with {@code auto-index-creation=true} and may already
+ * carry a Spring-named index over the same keys.
+ *
+ * <ul>
+ *   <li>{@code workflow_runs.workflow_ref_creation {workflowRef:1, creationDate:1}} - the monthly
+ *       quota count ({@code workflowRef $in} + the calendar-month {@code creationDate} range). Also
+ *       serves the insights date-window queries ({@code WorkflowRunService.insights} and the
+ *       date-bounded {@code count}), which filter {@code workflowRef $in} + {@code creationDate}.
+ *   <li>{@code workflow_runs.workflow_ref_status {workflowRef:1, status:1}} - the concurrent quota
+ *       count ({@code workflowRef $in} + {@code status $in (notstarted, ready, running, waiting)}).
+ * </ul>
+ */
+@Change(id = "0041-quota-count-indexes", author = "boomerang", transactional = false)
+@TargetSystem(id = "flow-mongodb")
+public class _0041__QuotaCountIndexes {
+
+  @Apply
+  public void execute(MongoDatabase db, CollectionNames names) {
+    String workflowRuns = names.resolve("workflow_runs");
+    ensureIndexKeys(
+        db,
+        workflowRuns,
+        "workflow_ref_creation",
+        new Document("workflowRef", 1).append("creationDate", 1),
+        new IndexOptions());
+    ensureIndexKeys(
+        db,
+        workflowRuns,
+        "workflow_ref_status",
+        new Document("workflowRef", 1).append("status", 1),
+        new IndexOptions());
+  }
+
+  @Rollback
+  public void rollback(MongoDatabase db, CollectionNames names) {
+    String workflowRuns = names.resolve("workflow_runs");
+    dropIndex(db, workflowRuns, "workflow_ref_creation");
+    dropIndex(db, workflowRuns, "workflow_ref_status");
+  }
+}

--- a/service-loader/src/test/java/io/boomerang/loader/LoaderMigrationTest.java
+++ b/service-loader/src/test/java/io/boomerang/loader/LoaderMigrationTest.java
@@ -327,6 +327,7 @@ class LoaderMigrationTest {
     assertDefinitionIndexes();
     assertRelationshipAndAuditIndexes();
     assertSweepIndexes();
+    assertQuotaCountIndexes();
     assertWorkspaceRenameApplied();
     assertV4ResidualCollectionsDropped();
     assertWorkerFlowImagesRepointed();
@@ -1374,6 +1375,15 @@ class LoaderMigrationTest {
     assertIndex("workflow_runs", "workflow_ref_phase", List.of("workflowRef", "phase"));
     assertIndex("task_runs", "claimed_sweep", List.of("phase", "claim.at"));
     assertIndex("actions", "status_sweep", List.of("status", "creationDate"));
+  }
+
+  /**
+   * {@code _0041}: the quota-count indexes. Both quota counters anchor on {@code workflowRef $in},
+   * which only {@code workflow_ref_phase} prefixes - and neither count filters {@code phase}.
+   */
+  private void assertQuotaCountIndexes() {
+    assertIndex("workflow_runs", "workflow_ref_creation", List.of("workflowRef", "creationDate"));
+    assertIndex("workflow_runs", "workflow_ref_status", List.of("workflowRef", "status"));
   }
 
   private void assertWorkspaceRenameApplied() {


### PR DESCRIPTION
Fixes #347.

## Reproduced on feat-v5

8 simultaneous submits against a workspace whose quota allows 1 were **all admitted (8/8)** — for both `maxConcurrentRuns` and `maxWorkflowRunMonthly`. Two defects compounded:

1. **The counters were dead, not just racy.** `canRunWithQuotas` reads `CurrentQuotas`, whose run counters come from `InsightsService` — which counts `workflowrun`-scope **audit records that nothing writes** (`AuditScope.WORKFLOWRUN` has no writer anywhere in `service-core`; `AuditInterceptor` covers WORKFLOW/WORKSPACE only). `currentRuns` and `currentConcurrentRuns` were always 0, so the run quotas could never trip even sequentially.
2. **The check is read-then-insert.** Even with real counters, every racer reads a count below the limit before any of them inserts, so a burst breaks through — exactly the parallel-subworkflow scenario in the issue.

## Fix (no DAGUtility / TaskExecutionService changes; no data-model changes)

| Where | Change |
| --- | --- |
| `WorkspaceService.setCurrentQuotas` (WorkspaceService.java:1003) | The two quota counters now count the live WorkflowRun collection, reusing `WorkflowRunService.count`. Monthly = runs created in the current month; concurrent = admitted and not yet terminal (`notstarted`/`ready`/`running`/`waiting`). Duration stats still come from the insight. |
| `WorkflowService.canRunWithQuotas` (WorkflowService.java:942) | Pre-admission check refuses at the limit (`>=`): the run being submitted is not counted yet, so at-the-limit already means it would exceed. (Previously `>`, so a limit of N admitted N+1.) |
| `WorkflowService.internalSubmit` (WorkflowService.java:680) + `guardQuotasAfterAdmission` (:1006) | **Admit-then-recheck** closes the race: with quotas enforced the run is created un-started, the counts are re-read (now including this run), and a run that pushed a count over its limit is discarded (`discardRun` :1030 removes the run and its materialised TaskRuns) and refused with `QUOTA_EXCEEDED` — before it is started or linked. The start (when requested and the run has no Workspaces, mirroring `WorkflowRunService.run`) happens only after the guard and the ownership edge. |

**Why the limit cannot be over-filled:** every racer re-checks *after* its own insert. If more than N were admitted, the racer whose re-check ran last would have seen every earlier admitted racer's document plus its own — i.e. more than N — and would have withdrawn. Racers may *mutually* withdraw (each counted the other), which can under-fill a slot; that is the safe direction, and the pinning test proves a follow-up submit then fills exactly the remaining slot.

## Deviations called out (per the repo's default-to-existing-model rule)

- **Counting source moved from audit records to the live collection.** The audit-based design intentionally included deleted workflows' runs; live counting does not, so deleting a workflow releases its runs from the monthly count. Given the audit writer never shipped in v5, live counting restores enforcement; restoring workflowrun audit records is a separable decision.
- **"Concurrent" now counts queued work**, not only `phase == running` — admission-time enforcement is meaningless if unstarted admitted runs are free.
- No new fields, collections, or indexes. The counts reuse `WorkflowRunService.count`, which fetches entities to group by status — per-submit cost is two of those queries; worth an index/aggregation pass if it shows up under load.

## Known gaps left as-is (pre-existing, flagged for follow-up)

- `canCreateWithQuotas` (workflow-count quota) keeps its `>` off-by-one and read-then-insert shape.
- The retry paths (`WorkflowRunService.retry`, engine auto-retry) create runs without passing quota checks.
- A quota-doomed run with Workspaces is briefly claimable for provisioning before it is discarded (it is never started by this path).

## Evidence

`StandaloneQuotaConcurrentSubmitTest` (new): 8 simultaneous submits, quota of 1 — before the fix both tests fail with `monthly quota of 1 admitted 8 of 8 submits`; after, at most one is admitted, a follow-up fills exactly the remaining slot, one more is refused, and exactly one WorkflowRun document exists.

Ran 3x plus the quota sweep (`mvn -o -pl service-core -am test -Dtest='*Quota*'`), all green:

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 -- in io.boomerang.workflow.StandaloneQuotaConcurrentSubmitTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 -- in io.boomerang.workflow.StandaloneQuotaEnforcementTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0 -- in io.boomerang.workspace.FlowQuotaPropertiesTest
```
