### PR TITLE
Run-lifecycle audit events and an audit-backed monthly run quota

### DIFF
--- a/client-web/src/Features/Insights/Insights.spec.tsx
+++ b/client-web/src/Features/Insights/Insights.spec.tsx
@@ -57,6 +57,13 @@ describe("WorkflowInsights --- Snapshot", () => {
 });
 
 describe("WorkflowInsights --- RTL", () => {
+  test("explains that insights come from the audit trail and include deleted Workflows", async () => {
+    renderInsights();
+    expect(
+      await screen.findByText(/Workflows and runs that have since been deleted are included/),
+    ).toBeInTheDocument();
+  });
+
   test("filtering by status updates the URL search params", async () => {
     const { history } = renderInsights();
     await screen.findByTestId("completed-insights");

--- a/client-web/src/Features/Insights/Insights.tsx
+++ b/client-web/src/Features/Insights/Insights.tsx
@@ -224,7 +224,11 @@ function InsightsContainer({ workspace, children }: InsightsContainerProps) {
         header={
           <>
             <HeaderTitle>Insights</HeaderTitle>
-            <HeaderSubtitle>Gain valuable insight by digging deeper into the Workflow runs</HeaderSubtitle>
+            <HeaderSubtitle>
+              Gain valuable insight by digging deeper into the Workflow runs. Insights are drawn
+              from the audit trail, so Workflows and runs that have since been deleted are
+              included for as long as the audit retention keeps them.
+            </HeaderSubtitle>
           </>
         }
       />

--- a/client-web/src/Features/Insights/__snapshots__/Insights.spec.tsx.snap
+++ b/client-web/src/Features/Insights/__snapshots__/Insights.spec.tsx.snap
@@ -54,7 +54,7 @@ exports[`WorkflowInsights --- Snapshot > Capturing Snapshot of WorkflowInsights 
           <p
             class="cds--bmrg-feature-header-title"
           >
-            Gain valuable insight by digging deeper into the Workflow runs
+            Gain valuable insight by digging deeper into the Workflow runs. Insights are drawn from the audit trail, so Workflows and runs that have since been deleted are included for as long as the audit retention keeps them.
           </p>
         </div>
       </section>

--- a/client-web/src/Features/WorkspaceDetailed/Quotas/Quotas.tsx
+++ b/client-web/src/Features/WorkspaceDetailed/Quotas/Quotas.tsx
@@ -165,6 +165,9 @@ function Quotas() {
             coverageBarStyle={coverageBarStyle}
           />
           <p className={styles.detailedSmallText}>{`Current usage: ${workspace.quotas.currentRuns}`}</p>
+          <p className={styles.detailedSmallText}>
+            Monthly counts include Workflows and runs that have since been deleted.
+          </p>
         </QuotaCard>
         <QuotaCard
           subtitle="Maximum amount of time that a single Workflow can take for one run (execution)."

--- a/client-web/src/Features/WorkspaceDetailed/WorkspaceDetailed.spec.tsx
+++ b/client-web/src/Features/WorkspaceDetailed/WorkspaceDetailed.spec.tsx
@@ -85,6 +85,10 @@ describe("WorkspaceDetailed --- nested tab routes", () => {
         "The following quotas have been set for the workspace - only administrators have access to adjust these.",
       ),
     ).toBeInTheDocument();
+    // The monthly execution counter is audit-backed, so it keeps counting deleted Workflows' runs.
+    expect(
+      screen.getByText("Monthly counts include Workflows and runs that have since been deleted."),
+    ).toBeInTheDocument();
     // The Members tab's own body must NOT be mounted - each tab is its own route now.
     expect(screen.queryByText("These are the people who have access to this Workspace.")).not.toBeInTheDocument();
   });

--- a/service-core/src/main/java/io/boomerang/core/audit/AuditAspect.java
+++ b/service-core/src/main/java/io/boomerang/core/audit/AuditAspect.java
@@ -114,6 +114,7 @@ public class AuditAspect {
               http.path(),
               durationMs,
               errorSummary(error),
+              null,
               null));
     } catch (RuntimeException e) {
       // Audit assembly must never break the request - the outcome (including the original

--- a/service-core/src/main/java/io/boomerang/core/audit/AuditEventEmitter.java
+++ b/service-core/src/main/java/io/boomerang/core/audit/AuditEventEmitter.java
@@ -5,6 +5,7 @@ import io.boomerang.core.model.SettingConfig;
 import io.boomerang.core.model.Token;
 import io.boomerang.core.repository.SettingsRepository;
 import io.boomerang.core.security.IdentityService;
+import java.util.Map;
 import org.springframework.stereotype.Service;
 
 /**
@@ -79,7 +80,45 @@ public class AuditEventEmitter {
             http.path(),
             null,
             errorSummary,
-            detail));
+            detail,
+            null));
+  }
+
+  /**
+   * Emit as an explicitly resolved actor with a caller-supplied payload — for sites without a
+   * request to attribute (the engine's run transition listener). The attempt already happened,
+   * so the outcome is always SUCCESS. Gate-checked.
+   */
+  public void emitAs(
+      AuditActor actor,
+      AuditAction action,
+      AuditLevel level,
+      String resourceType,
+      String resourceId,
+      String resourceName,
+      String workspaceId,
+      Map<String, Object> payload) {
+    if (!captureEnabled(level)) {
+      return;
+    }
+    writer.persist(
+        new AuditRecord(
+            actor,
+            workspaceId,
+            action,
+            level,
+            resourceType,
+            resourceId,
+            resourceName,
+            AuditOutcome.SUCCESS,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            payload));
   }
 
   /** The current actor: the token's identity, else anonymous over HTTP, else system. */

--- a/service-core/src/main/java/io/boomerang/core/audit/AuditEventWriter.java
+++ b/service-core/src/main/java/io/boomerang/core/audit/AuditEventWriter.java
@@ -65,6 +65,9 @@ public class AuditEventWriter {
     putIfPresent(payload, "durationMs", record.durationMs());
     putIfPresent(payload, "errorSummary", record.errorSummary());
     putIfPresent(payload, "detail", record.detail());
+    if (record.payload() != null) {
+      payload.putAll(record.payload());
+    }
     event.setPayload(payload);
     return event;
   }

--- a/service-core/src/main/java/io/boomerang/core/audit/AuditQueryService.java
+++ b/service-core/src/main/java/io/boomerang/core/audit/AuditQueryService.java
@@ -76,6 +76,7 @@ public class AuditQueryService {
       criteria.add(Criteria.where("payload." + payloadField.get()).in(payloadValues.get()));
     }
     Query query = new Query(new Criteria().andOperator(criteria.toArray(new Criteria[0])));
+    query.with(Sort.by(Sort.Direction.ASC, "time"));
     return mongoTemplate.find(query, AuditEventEntity.class);
   }
 

--- a/service-core/src/main/java/io/boomerang/core/audit/AuditQueryService.java
+++ b/service-core/src/main/java/io/boomerang/core/audit/AuditQueryService.java
@@ -80,6 +80,22 @@ public class AuditQueryService {
     return mongoTemplate.find(query, AuditEventEntity.class);
   }
 
+  /**
+   * Count run-creation events for one workspace in a time window — the monthly quota counter in
+   * {@code WorkspaceService.setCurrentQuotas}. Served by the {@code workspace_time} index.
+   */
+  public long countRunsCreated(String workspaceId, Date from, Date to) {
+    Query query =
+        new Query(
+            new Criteria()
+                .andOperator(
+                    Criteria.where("workspaceId").is(workspaceId),
+                    Criteria.where("action").is(AuditAction.CREATE.name()),
+                    Criteria.where("resourceType").is("workflowrun"),
+                    Criteria.where("time").gte(from).lt(to)));
+    return mongoTemplate.count(query, AuditEventEntity.class);
+  }
+
   private static Optional<Criteria> timeRange(Optional<Date> from, Optional<Date> to) {
     if (from.isEmpty() && to.isEmpty()) {
       return Optional.empty();

--- a/service-core/src/main/java/io/boomerang/core/audit/AuditRecord.java
+++ b/service-core/src/main/java/io/boomerang/core/audit/AuditRecord.java
@@ -1,9 +1,14 @@
 package io.boomerang.core.audit;
 
+import java.util.Map;
+
 /**
  * Immutable capture of one audited attempt, assembled synchronously on the calling thread (the
  * SecurityContext and RequestContextHolder thread-locals must not cross into the async writer) and
  * handed to {@link AuditEventWriter#persist(AuditRecord)}.
+ *
+ * <p>{@code payload} carries caller-supplied discriminators (ids, short summaries — never
+ * content) merged into the event's payload after the request fields; null when the site has none.
  */
 public record AuditRecord(
     AuditActor actor,
@@ -20,4 +25,5 @@ public record AuditRecord(
     String requestPath,
     Long durationMs,
     String errorSummary,
-    String detail) {}
+    String detail,
+    Map<String, Object> payload) {}

--- a/service-core/src/main/java/io/boomerang/core/audit/WorkflowRunAuditBridge.java
+++ b/service-core/src/main/java/io/boomerang/core/audit/WorkflowRunAuditBridge.java
@@ -1,0 +1,162 @@
+package io.boomerang.core.audit;
+
+import io.boomerang.common.entity.WorkflowRunEntity;
+import io.boomerang.common.enums.RunPhase;
+import io.boomerang.common.enums.RunStatus;
+import io.boomerang.core.RelationshipService;
+import io.boomerang.core.enums.RelationshipLabel;
+import io.boomerang.core.enums.RelationshipType;
+import io.boomerang.core.security.IdentityService;
+import io.boomerang.engine.model.WorkflowRunTransition;
+import io.boomerang.engine.repository.WorkflowRunRepository;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Bridge from the winner-published WorkflowRun transition events to the audit trail: the run's
+ * first status change records a CREATE event and reaching the completed phase records an UPDATE
+ * event carrying the terminal facts (status, duration). These events outlive the run documents
+ * and the Workflow itself, so the monthly run quota counter and the workspace insights read them
+ * rather than the live collections — deleting a Workflow cannot reset either.
+ *
+ * <p>TaskRun transitions are deliberately not audited: their volume would dwarf every other
+ * event in the trail, and no consumer needs them (quotas and insights are WorkflowRun-scoped).
+ *
+ * <p>The actor is the current principal when the transition happens on a request thread (a
+ * manual submit or cancel), else the system sentinel (watcher sweeps, schedule fires). Emission
+ * is best-effort and never fails the transition.
+ */
+@Component
+public class WorkflowRunAuditBridge {
+
+  private static final Logger LOGGER = LogManager.getLogger();
+
+  static final String RESOURCE_TYPE = "workflowrun";
+
+  private final AuditEventEmitter emitter;
+  private final IdentityService identityService;
+  private final RelationshipService relationshipService;
+  private final WorkflowRunRepository workflowRunRepository;
+
+  public WorkflowRunAuditBridge(
+      AuditEventEmitter emitter,
+      IdentityService identityService,
+      RelationshipService relationshipService,
+      WorkflowRunRepository workflowRunRepository) {
+    this.emitter = emitter;
+    this.identityService = identityService;
+    this.relationshipService = relationshipService;
+    this.workflowRunRepository = workflowRunRepository;
+  }
+
+  @EventListener
+  public void onWorkflowRunTransition(WorkflowRunTransition transition) {
+    try {
+      if (!emitter.captureEnabled(AuditLevel.WRITE)) {
+        return;
+      }
+      // The first status change away from notstarted happens exactly once per run (admission,
+      // or a direct cancel of a never-admitted run); so does reaching the completed phase (the
+      // completion Compare-And-Set). A cancel straight out of notstarted is both at once.
+      boolean created =
+          RunStatus.notstarted == transition.fromStatus()
+              && RunStatus.notstarted != transition.toStatus();
+      boolean completed =
+          RunPhase.completed == transition.toPhase()
+              && RunPhase.completed != transition.fromPhase();
+      if (!created && !completed) {
+        return;
+      }
+      AuditActor actor = currentActorOrSystem();
+      String workflowName = slugOrNull(RelationshipType.WORKFLOW, transition.workflowRef());
+      String workspace = owningWorkspace(transition);
+      if (created) {
+        emitter.emitAs(
+            actor,
+            AuditAction.CREATE,
+            AuditLevel.WRITE,
+            RESOURCE_TYPE,
+            transition.id(),
+            workflowName,
+            workspace,
+            payload(transition, workflowName, null));
+      }
+      if (completed) {
+        // The completion Compare-And-Set wrote the duration before publishing this event.
+        Long duration =
+            workflowRunRepository
+                .findById(transition.id())
+                .map(WorkflowRunEntity::getDuration)
+                .orElse(0L);
+        emitter.emitAs(
+            actor,
+            AuditAction.UPDATE,
+            AuditLevel.WRITE,
+            RESOURCE_TYPE,
+            transition.id(),
+            workflowName,
+            workspace,
+            payload(transition, workflowName, duration));
+      }
+    } catch (RuntimeException e) {
+      LOGGER.warn(
+          "Failed to audit WorkflowRun {} transition: {}", transition.id(), e.toString());
+    }
+  }
+
+  /** The run facts the insights rollup reads back off the event. */
+  private static Map<String, Object> payload(
+      WorkflowRunTransition transition, String workflowName, Long duration) {
+    Map<String, Object> payload = new HashMap<>();
+    payload.put("workflowRef", transition.workflowRef());
+    if (workflowName != null) {
+      payload.put("workflowName", workflowName);
+    }
+    payload.put("status", transition.toStatus().getStatus());
+    payload.put("phase", transition.toPhase().getPhase());
+    if (duration != null) {
+      payload.put("duration", duration);
+    }
+    return payload;
+  }
+
+  private AuditActor currentActorOrSystem() {
+    AuditActor actor = AuditActor.from(identityService.getCurrentIdentity());
+    return (actor != null) ? actor : AuditActor.system();
+  }
+
+  /**
+   * Resolve the owning Workspace's name from the Workflow's parent edge, the way the Action
+   * rollup does. An unresolvable owner (already-deleted Workflow, engine mode without a graph)
+   * audits with none rather than failing the transition.
+   */
+  private String owningWorkspace(WorkflowRunTransition transition) {
+    try {
+      String parentRef =
+          relationshipService.getParentByLabel(
+              RelationshipLabel.HAS_WORKFLOW, RelationshipType.WORKFLOW, transition.workflowRef());
+      if (parentRef != null && !parentRef.isBlank()) {
+        return relationshipService.getSlugByRefForType(RelationshipType.WORKSPACE, parentRef);
+      }
+    } catch (RuntimeException e) {
+      // Fall through to the unresolved log below.
+    }
+    LOGGER.warn(
+        "[{}] No owning Workspace resolves for Workflow {} - auditing without one.",
+        transition.id(),
+        transition.workflowRef());
+    return null;
+  }
+
+  private String slugOrNull(RelationshipType type, String ref) {
+    try {
+      return relationshipService.getSlugByRefForType(type, ref);
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+}

--- a/service-core/src/main/java/io/boomerang/workflow/WorkflowRunService.java
+++ b/service-core/src/main/java/io/boomerang/workflow/WorkflowRunService.java
@@ -240,6 +240,37 @@ public class WorkflowRunService {
     return count(from.map(Date::new), to.map(Date::new), queryLabels, Optional.of(wfRefs));
   }
 
+  /**
+   * Count runs matching the given Workflows with a single server-side count - no documents are
+   * fetched and nothing is grouped in memory. Serves the quota counters in {@code
+   * WorkspaceService.setCurrentQuotas}: the monthly counter passes the calendar-month {@code
+   * creationDate} window with no statuses, the concurrent counter passes the non-terminal statuses
+   * with no window.
+   */
+  public long countForQuota(
+      List<String> workflowRefs,
+      Optional<Date> from,
+      Optional<Date> to,
+      Optional<Set<RunStatus>> statuses) {
+    List<Criteria> criteriaList = new ArrayList<>();
+    criteriaList.add(Criteria.where("workflowRef").in(workflowRefs));
+    if (from.isPresent() && !to.isPresent()) {
+      criteriaList.add(Criteria.where("creationDate").gte(from.get()));
+    } else if (!from.isPresent() && to.isPresent()) {
+      criteriaList.add(Criteria.where("creationDate").lt(to.get()));
+    } else if (from.isPresent() && to.isPresent()) {
+      criteriaList.add(Criteria.where("creationDate").gte(from.get()).lt(to.get()));
+    }
+    if (statuses.isPresent()) {
+      criteriaList.add(Criteria.where("status").in(statuses.get()));
+    }
+    Query query =
+        new Query(
+            new Criteria().andOperator(criteriaList.toArray(new Criteria[criteriaList.size()])));
+    LOGGER.debug("Quota count query: {}", query);
+    return mongoTemplate.count(query, WorkflowRunEntity.class);
+  }
+
   /*
    * Start WorkflowRun
    *

--- a/service-core/src/main/java/io/boomerang/workflow/WorkflowService.java
+++ b/service-core/src/main/java/io/boomerang/workflow/WorkflowService.java
@@ -10,6 +10,7 @@ import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import io.boomerang.common.entity.TaskRevisionEntity;
+import io.boomerang.common.entity.TaskRunEntity;
 import io.boomerang.common.entity.WorkflowEntity;
 import io.boomerang.common.entity.WorkflowRevisionEntity;
 import io.boomerang.common.entity.WorkflowRunEntity;
@@ -673,7 +674,14 @@ public class WorkflowService {
     executionAnnotations.put("boomerang.io/workspace-name", team);
     request.getAnnotations().putAll(executionAnnotations);
 
-    WorkflowRun wfRun = submit(workflowId, request, start, initiatedByRef);
+    // Admit-then-recheck: with quotas enforced the run is created un-started, the quota counts
+    // are re-read (now including this run), and a run that pushed a count over its limit is
+    // discarded - simultaneous submits cannot each slip past the pre-admission count above.
+    boolean enforceQuotas = quotasEnforced();
+    WorkflowRun wfRun = submit(workflowId, request, start && !enforceQuotas, initiatedByRef);
+    if (enforceQuotas) {
+      guardQuotasAfterAdmission(team, wfRun.getId());
+    }
 
     // Creates relationship with owning team
     // TODO: create this run relationship based on decision of team vs workflow
@@ -686,6 +694,13 @@ public class WorkflowService {
         wfRun.getId(),
         Optional.empty(),
         Optional.empty());
+    // A run with Workspaces stays ready/pending for the dispatcher to provision and start -
+    // the same rule WorkflowRunService.run applies on the un-enforced path.
+    if (enforceQuotas
+        && start
+        && (wfRun.getWorkspaces() == null || wfRun.getWorkspaces().isEmpty())) {
+      wfRun = workflowRunService.start(wfRun.getId(), Optional.empty());
+    }
     return wfRun;
   }
 
@@ -928,13 +943,15 @@ public class WorkflowService {
     if (quotasEnforced()) {
       CurrentQuotas quotas = workspaceService.getObject().getCurrentQuotas(team);
       LOGGER.debug("Quotas: {}", quotas.toString());
-      if (quotas.getCurrentConcurrentRuns() > quotas.getMaxConcurrentRuns()) {
+      // The run being submitted is not counted yet, so at-the-limit already means it would
+      // exceed the limit.
+      if (quotas.getCurrentConcurrentRuns() >= quotas.getMaxConcurrentRuns()) {
         throw new BoomerangException(
             BoomerangError.QUOTA_EXCEEDED,
             "Concurrent runs (executions)",
             quotas.getCurrentConcurrentRuns(),
             quotas.getMaxConcurrentRuns());
-      } else if (quotas.getCurrentRuns() > quotas.getMaxWorkflowRunMonthly()) {
+      } else if (quotas.getCurrentRuns() >= quotas.getMaxWorkflowRunMonthly()) {
         throw new BoomerangException(
             BoomerangError.QUOTA_EXCEEDED,
             "Number of runs (executions)",
@@ -979,6 +996,42 @@ public class WorkflowService {
                 });
       }
     }
+  }
+
+  /*
+   * Re-checks the run quotas after a WorkflowRun has been admitted. The counts now include the
+   * run itself, so a burst of simultaneous submits cannot each pass the pre-admission count:
+   * every run that pushed a count over its limit removes itself and its submit fails.
+   */
+  private void guardQuotasAfterAdmission(String team, String workflowRunId) {
+    CurrentQuotas quotas = workspaceService.getObject().getCurrentQuotas(team);
+    if (quotas.getCurrentConcurrentRuns() > quotas.getMaxConcurrentRuns()) {
+      discardRun(workflowRunId);
+      throw new BoomerangException(
+          BoomerangError.QUOTA_EXCEEDED,
+          "Concurrent runs (executions)",
+          quotas.getCurrentConcurrentRuns(),
+          quotas.getMaxConcurrentRuns());
+    } else if (quotas.getCurrentRuns() > quotas.getMaxWorkflowRunMonthly()) {
+      discardRun(workflowRunId);
+      throw new BoomerangException(
+          BoomerangError.QUOTA_EXCEEDED,
+          "Number of runs (executions)",
+          quotas.getCurrentRuns(),
+          quotas.getMaxWorkflowRunMonthly());
+    }
+  }
+
+  /*
+   * Removes a quota-rejected WorkflowRun and its materialised TaskRuns. The run was never
+   * started and no relationship edge exists yet, so removing the documents is the whole undo -
+   * and keeps a rejected submit from consuming quota itself.
+   */
+  private void discardRun(String workflowRunId) {
+    mongoTemplate.remove(
+        Query.query(Criteria.where("workflowRunRef").is(workflowRunId)), TaskRunEntity.class);
+    mongoTemplate.remove(
+        Query.query(Criteria.where("_id").is(workflowRunId)), WorkflowRunEntity.class);
   }
 
   /*

--- a/service-core/src/main/java/io/boomerang/workspace/InsightsService.java
+++ b/service-core/src/main/java/io/boomerang/workspace/InsightsService.java
@@ -10,18 +10,23 @@ import io.boomerang.core.RelationshipService;
 import io.boomerang.core.audit.AuditEventEntity;
 import io.boomerang.core.audit.AuditQueryService;
 import io.boomerang.core.enums.RelationshipType;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
 
 /**
  * Workspace insights rolled up from the audit trail's workflow-run events, so deleted Workflows
- * and WorkflowRuns still count. Reads events with {@code resourceType="workflowrun"} whose payload
- * carries the run facts ({@code workflowRef}, {@code workflowName}, {@code duration}, {@code
- * status}, {@code phase}) — the run lifecycle emission that writes them rides the engine's
- * transition listener.
+ * and WorkflowRuns still count. Reads events with {@code resourceType="workflowrun"} whose
+ * payload carries the run facts ({@code workflowRef}, {@code workflowName}, {@code duration},
+ * {@code status}, {@code phase}) — written by the engine's transition listener ({@code
+ * core.audit.WorkflowRunAuditBridge}): a CREATE event on the run's first status change and an
+ * UPDATE event when it completes. The events per run are collapsed to one summary — the earliest
+ * dates it, the latest carries its current facts.
  */
 @Service
 @ConditionalOnFlowMode(FlowMode.STANDALONE)
@@ -56,32 +61,40 @@ public class InsightsService {
                   false));
     }
 
+    // Time-ascending, so per run the first event is its creation and the last its latest state.
     List<AuditEventEntity> events =
         auditQueryService.findByWorkspaceAndResourceType(
             team, "workflowrun", from, to, wfRefs.map(refs -> "workflowRef"), wfRefs);
+    Map<String, List<AuditEventEntity>> byRun = new LinkedHashMap<>();
+    for (AuditEventEntity event : events) {
+      byRun.computeIfAbsent(event.getResourceId(), id -> new ArrayList<>()).add(event);
+    }
 
     WorkflowRunInsight insight = new WorkflowRunInsight();
     long totalDuration = 0L;
+    long inFlight = 0L;
     List<WorkflowRunSummary> summaries = new LinkedList<>();
-    for (AuditEventEntity event : events) {
-      long duration = payloadLong(event, "duration");
+    for (List<AuditEventEntity> runEvents : byRun.values()) {
+      AuditEventEntity first = runEvents.get(0);
+      AuditEventEntity latest = runEvents.get(runEvents.size() - 1);
+      long duration = payloadLong(latest, "duration");
       totalDuration += duration;
+      if (!RunPhase.completed.getPhase().equals(payloadString(latest, "phase"))) {
+        inFlight++;
+      }
 
       WorkflowRunSummary summary = new WorkflowRunSummary();
-      summary.setCreationDate(event.getTime());
+      summary.setCreationDate(first.getTime());
       summary.setDuration(duration);
-      summary.setStatus(RunStatus.getRunStatus(payloadString(event, "status")));
-      summary.setWorkflowRef(payloadString(event, "workflowRef"));
-      summary.setWorkflowName(payloadString(event, "workflowName"));
+      summary.setStatus(RunStatus.getRunStatus(payloadString(latest, "status")));
+      summary.setWorkflowRef(payloadString(latest, "workflowRef"));
+      summary.setWorkflowName(payloadString(latest, "workflowName"));
       summaries.add(summary);
     }
-    insight.setTotalRuns((long) events.size());
-    insight.setConcurrentRuns(
-        events.stream()
-            .filter(event -> RunPhase.running.getPhase().equals(payloadString(event, "phase")))
-            .count());
+    insight.setTotalRuns((long) byRun.size());
+    insight.setConcurrentRuns(inFlight);
     insight.setTotalDuration(totalDuration);
-    insight.setMedianDuration(events.isEmpty() ? 0L : totalDuration / events.size());
+    insight.setMedianDuration(byRun.isEmpty() ? 0L : totalDuration / byRun.size());
     insight.setRuns(summaries);
     return insight;
   }

--- a/service-core/src/main/java/io/boomerang/workspace/WorkspaceService.java
+++ b/service-core/src/main/java/io/boomerang/workspace/WorkspaceService.java
@@ -2,6 +2,7 @@ package io.boomerang.workspace;
 
 import static io.boomerang.common.util.DataAdapterUtil.filterValueByFieldType;
 
+import io.boomerang.core.audit.AuditQueryService;
 import io.boomerang.workflow.WorkflowRunService;
 import io.boomerang.workflow.WorkflowService;
 import io.boomerang.common.model.AbstractParam;
@@ -99,6 +100,7 @@ public class WorkspaceService {
   private final InsightsService insightsService;
   private final WorkflowService workflowService;
   private final WorkflowRunService workflowRunService;
+  private final AuditQueryService auditQueryService;
   private final TokenService tokenService;
   private final TaskService taskService;
 
@@ -114,6 +116,7 @@ public class WorkspaceService {
       InsightsService insightsService,
       WorkflowService workflowService,
       WorkflowRunService workflowRunService,
+      AuditQueryService auditQueryService,
       TokenService tokenService,
       TaskService taskService) {
     this.workspaceRepository = workspaceRepository;
@@ -127,6 +130,7 @@ public class WorkspaceService {
     this.insightsService = insightsService;
     this.workflowService = workflowService;
     this.workflowRunService = workflowRunService;
+    this.auditQueryService = auditQueryService;
     this.tokenService = tokenService;
     this.taskService = taskService;
   }
@@ -1039,9 +1043,9 @@ public class WorkspaceService {
     currentQuotas.setCurrentRunTotalDuration(insight.getTotalDuration().intValue());
     currentQuotas.setCurrentRunMedianDuration(insight.getMedianDuration().intValue());
 
-    // The run counters that quotas enforce come from the live WorkflowRun collection - the
-    // audit-derived insight cannot serve them, as no workflowrun-scope audit record is written.
-    // Concurrent = admitted and not yet terminal, so queued work counts against the limit.
+    // Concurrent = admitted and not yet terminal from the live WorkflowRun collection, so queued
+    // work counts against the limit - it measures what is running now, which deletion
+    // legitimately reduces.
     List<String> workflowRefs =
         relationshipService.filter(
             RelationshipType.WORKFLOW,
@@ -1049,13 +1053,20 @@ public class WorkspaceService {
             Optional.of(RelationshipType.WORKSPACE),
             Optional.of(List.of(team)),
             false);
-    currentQuotas.setCurrentRuns(
-        (int)
-            workflowRunService.countForQuota(
-                workflowRefs,
-                Optional.of(currentMonthStart.getTime()),
-                Optional.of(nextMonth.getTime()),
-                Optional.empty()));
+    // Monthly = max(audit count, live count), deliberately: the audit write is async best-effort,
+    // so a just-admitted run may not be audited yet (the live count covers that race), while a
+    // deleted Workflow's runs leave the live count (the audit count covers deletion - the CREATE
+    // events outlive both the run documents and the Workflow).
+    long liveMonthly =
+        workflowRunService.countForQuota(
+            workflowRefs,
+            Optional.of(currentMonthStart.getTime()),
+            Optional.of(nextMonth.getTime()),
+            Optional.empty());
+    long auditMonthly =
+        auditQueryService.countRunsCreated(
+            team, currentMonthStart.getTime(), nextMonth.getTime());
+    currentQuotas.setCurrentRuns((int) Math.max(auditMonthly, liveMonthly));
     currentQuotas.setCurrentConcurrentRuns(
         (int)
             workflowRunService.countForQuota(

--- a/service-core/src/main/java/io/boomerang/workspace/WorkspaceService.java
+++ b/service-core/src/main/java/io/boomerang/workspace/WorkspaceService.java
@@ -2,9 +2,11 @@ package io.boomerang.workspace;
 
 import static io.boomerang.common.util.DataAdapterUtil.filterValueByFieldType;
 
+import io.boomerang.workflow.WorkflowRunService;
 import io.boomerang.workflow.WorkflowService;
 import io.boomerang.common.model.AbstractParam;
 import io.boomerang.common.model.WorkflowCount;
+import io.boomerang.common.enums.RunStatus;
 import io.boomerang.common.model.WorkflowRunInsight;
 import io.boomerang.common.util.DataAdapterUtil.FieldType;
 import io.boomerang.common.util.ParameterUtil;
@@ -95,6 +97,7 @@ public class WorkspaceService {
   private final MongoTemplate mongoTemplate;
   private final InsightsService insightsService;
   private final WorkflowService workflowService;
+  private final WorkflowRunService workflowRunService;
   private final TokenService tokenService;
   private final TaskService taskService;
 
@@ -109,6 +112,7 @@ public class WorkspaceService {
       MongoTemplate mongoTemplate,
       InsightsService insightsService,
       WorkflowService workflowService,
+      WorkflowRunService workflowRunService,
       TokenService tokenService,
       TaskService taskService) {
     this.workspaceRepository = workspaceRepository;
@@ -121,6 +125,7 @@ public class WorkspaceService {
     this.mongoTemplate = mongoTemplate;
     this.insightsService = insightsService;
     this.workflowService = workflowService;
+    this.workflowRunService = workflowRunService;
     this.tokenService = tokenService;
     this.taskService = taskService;
   }
@@ -1030,10 +1035,32 @@ public class WorkspaceService {
             Optional.empty(),
             Optional.empty());
     LOGGER.debug("Insights: {}", insight.toString());
-    currentQuotas.setCurrentConcurrentRuns(insight.getConcurrentRuns().intValue());
     currentQuotas.setCurrentRunTotalDuration(insight.getTotalDuration().intValue());
     currentQuotas.setCurrentRunMedianDuration(insight.getMedianDuration().intValue());
-    currentQuotas.setCurrentRuns(insight.getTotalRuns().intValue());
+
+    // The run counters that quotas enforce come from the live WorkflowRun collection - the
+    // audit-derived insight cannot serve them, as no workflowrun-scope audit record is written.
+    // Concurrent = admitted and not yet terminal, so queued work counts against the limit.
+    Map<String, Long> monthlyRuns =
+        workflowRunService
+            .count(
+                team,
+                Optional.of(currentMonthStart.getTimeInMillis()),
+                Optional.of(nextMonth.getTimeInMillis()),
+                Optional.empty(),
+                Optional.empty())
+            .getStatus();
+    currentQuotas.setCurrentRuns(monthlyRuns.get("all").intValue());
+    Map<String, Long> runsByStatus =
+        workflowRunService
+            .count(team, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+            .getStatus();
+    currentQuotas.setCurrentConcurrentRuns(
+        (int)
+            (runsByStatus.get(RunStatus.notstarted.getStatus())
+                + runsByStatus.get(RunStatus.ready.getStatus())
+                + runsByStatus.get(RunStatus.running.getStatus())
+                + runsByStatus.get(RunStatus.waiting.getStatus())));
 
     WorkflowCount count =
         workflowService.count(

--- a/service-core/src/main/java/io/boomerang/workspace/WorkspaceService.java
+++ b/service-core/src/main/java/io/boomerang/workspace/WorkspaceService.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -1041,26 +1042,32 @@ public class WorkspaceService {
     // The run counters that quotas enforce come from the live WorkflowRun collection - the
     // audit-derived insight cannot serve them, as no workflowrun-scope audit record is written.
     // Concurrent = admitted and not yet terminal, so queued work counts against the limit.
-    Map<String, Long> monthlyRuns =
-        workflowRunService
-            .count(
-                team,
-                Optional.of(currentMonthStart.getTimeInMillis()),
-                Optional.of(nextMonth.getTimeInMillis()),
-                Optional.empty(),
-                Optional.empty())
-            .getStatus();
-    currentQuotas.setCurrentRuns(monthlyRuns.get("all").intValue());
-    Map<String, Long> runsByStatus =
-        workflowRunService
-            .count(team, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
-            .getStatus();
+    List<String> workflowRefs =
+        relationshipService.filter(
+            RelationshipType.WORKFLOW,
+            Optional.empty(),
+            Optional.of(RelationshipType.WORKSPACE),
+            Optional.of(List.of(team)),
+            false);
+    currentQuotas.setCurrentRuns(
+        (int)
+            workflowRunService.countForQuota(
+                workflowRefs,
+                Optional.of(currentMonthStart.getTime()),
+                Optional.of(nextMonth.getTime()),
+                Optional.empty()));
     currentQuotas.setCurrentConcurrentRuns(
         (int)
-            (runsByStatus.get(RunStatus.notstarted.getStatus())
-                + runsByStatus.get(RunStatus.ready.getStatus())
-                + runsByStatus.get(RunStatus.running.getStatus())
-                + runsByStatus.get(RunStatus.waiting.getStatus())));
+            workflowRunService.countForQuota(
+                workflowRefs,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(
+                    Set.of(
+                        RunStatus.notstarted,
+                        RunStatus.ready,
+                        RunStatus.running,
+                        RunStatus.waiting))));
 
     WorkflowCount count =
         workflowService.count(

--- a/service-core/src/test/java/io/boomerang/core/audit/AuditEventWriterTest.java
+++ b/service-core/src/test/java/io/boomerang/core/audit/AuditEventWriterTest.java
@@ -30,7 +30,8 @@ class AuditEventWriterTest {
         "/api/v2/workspace/acme/workflow",
         12L,
         null,
-        null);
+        null,
+        java.util.Map.of("workflowRef", "wf1"));
   }
 
   @Test
@@ -66,6 +67,7 @@ class AuditEventWriterTest {
         .containsEntry("httpMethod", "POST")
         .containsEntry("requestPath", "/api/v2/workspace/acme/workflow")
         .containsEntry("durationMs", 12L)
+        .containsEntry("workflowRef", "wf1")
         .doesNotContainKeys("errorSummary", "detail");
   }
 }

--- a/service-core/src/test/java/io/boomerang/core/audit/WorkflowRunAuditBridgeTest.java
+++ b/service-core/src/test/java/io/boomerang/core/audit/WorkflowRunAuditBridgeTest.java
@@ -1,0 +1,170 @@
+package io.boomerang.core.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.boomerang.common.enums.RunPhase;
+import io.boomerang.common.enums.RunStatus;
+import io.boomerang.common.enums.TriggerEnum;
+import io.boomerang.common.model.WorkflowRun;
+import io.boomerang.common.model.WorkflowSubmitRequest;
+import io.boomerang.core.entity.SettingEntity;
+import io.boomerang.core.model.SettingConfig;
+import io.boomerang.engine.AbstractEngineIntegrationTest;
+import io.boomerang.engine.model.WorkflowRunTransition;
+import io.boomerang.workflow.WorkflowRunService;
+import io.boomerang.workflow.WorkflowService;
+import io.boomerang.workspace.WorkspaceService;
+import io.boomerang.workspace.model.Quotas;
+import io.boomerang.workspace.model.WorkspaceRequest;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+
+/**
+ * The engine's WorkflowRun transitions land in the audit trail: the first status change records a
+ * CREATE event owned by the run's Workspace, completion records an UPDATE event carrying the
+ * terminal status and duration, and an unresolvable owner still records the event (with no
+ * workspace) rather than failing the transition.
+ */
+class WorkflowRunAuditBridgeTest extends AbstractEngineIntegrationTest {
+
+  private static final String TASK_SLUG = "run-audit-bridge-test-task";
+
+  @Autowired private WorkflowService workflowService;
+  @Autowired private WorkflowRunService workflowRunService;
+  @Autowired private WorkspaceService workspaceService;
+  @Autowired private AuditEventRepository auditEventRepository;
+  @Autowired private ApplicationEventPublisher eventPublisher;
+
+  @BeforeEach
+  void seedFixtures() {
+    seedRelationshipRoot();
+    seedTeamQuotaSettings();
+    seedTaskSettings();
+    seedGlobalTask(TASK_SLUG);
+    setFeatureSetting("globalParameters", false);
+    setFeatureSetting("workspaceParameters", false);
+    setFeatureSetting("workspaceQuotas", false);
+    if (settingsRepository.findOneByKey("audit") == null) {
+      SettingEntity settings = new SettingEntity();
+      settings.setKey("audit");
+      settings.setName("Audit");
+      settings.setConfig(List.of(config("enabled", "true"), config("level", "WRITE")));
+      settingsRepository.save(settings);
+    }
+  }
+
+  /** Leaves the shared database as the other test classes expect it: capture off. */
+  @AfterEach
+  void removeAuditSettings() {
+    SettingEntity settings = settingsRepository.findOneByKey("audit");
+    if (settings != null) {
+      settingsRepository.delete(settings);
+    }
+  }
+
+  @Test
+  void anAdmittedRunRecordsACreateEventOwnedByItsWorkspace() {
+    String workspace = createWorkspace("run-audit-create-ws");
+    workflowService.create(workspace, runnableWorkflow("run-audit-create-workflow", TASK_SLUG));
+
+    WorkflowRun run =
+        workflowService.submit(workspace, "run-audit-create-workflow", manualRequest(), false);
+
+    awaitEngine("run CREATE audit event")
+        .untilAsserted(
+            () -> {
+              List<AuditEventEntity> events = eventsFor(run.getId(), "CREATE");
+              assertThat(events).hasSize(1);
+              AuditEventEntity event = events.get(0);
+              assertThat(event.getResourceType()).isEqualTo("workflowrun");
+              assertThat(event.getWorkspaceId()).isEqualTo(workspace);
+              assertThat(event.getResourceName()).isEqualTo("run-audit-create-workflow");
+              assertThat(event.getActorId()).isEqualTo("integration-test-principal");
+              assertThat(event.getOutcome()).isEqualTo("SUCCESS");
+              assertThat(event.getPayload())
+                  .containsEntry("workflowRef", run.getWorkflowRef())
+                  .containsEntry("workflowName", "run-audit-create-workflow")
+                  .containsEntry("status", "ready");
+            });
+  }
+
+  @Test
+  void aCompletedRunRecordsAnUpdateEventCarryingTheTerminalStatus() {
+    String workspace = createWorkspace("run-audit-terminal-ws");
+    workflowService.create(workspace, runnableWorkflow("run-audit-terminal-workflow", TASK_SLUG));
+    WorkflowRun run =
+        workflowService.submit(workspace, "run-audit-terminal-workflow", manualRequest(), false);
+
+    workflowRunService.cancel(run.getId());
+
+    awaitEngine("run terminal audit event")
+        .untilAsserted(
+            () -> {
+              List<AuditEventEntity> events = eventsFor(run.getId(), "UPDATE");
+              assertThat(events).hasSize(1);
+              AuditEventEntity event = events.get(0);
+              assertThat(event.getResourceType()).isEqualTo("workflowrun");
+              assertThat(event.getWorkspaceId()).isEqualTo(workspace);
+              assertThat(event.getPayload())
+                  .containsEntry("status", "cancelled")
+                  .containsEntry("phase", "completed")
+                  .containsKey("duration");
+            });
+  }
+
+  @Test
+  void anUnresolvableWorkspaceStillRecordsTheEventWithoutOne() {
+    String runId = "run-audit-orphan-" + System.nanoTime();
+
+    eventPublisher.publishEvent(
+        new WorkflowRunTransition(
+            runId,
+            "run-audit-missing-workflow-ref",
+            RunStatus.notstarted,
+            RunPhase.pending,
+            RunStatus.ready,
+            RunPhase.pending));
+
+    awaitEngine("orphan run audit event")
+        .untilAsserted(
+            () -> {
+              List<AuditEventEntity> events = eventsFor(runId, "CREATE");
+              assertThat(events).hasSize(1);
+              assertThat(events.get(0).getWorkspaceId()).isNull();
+              assertThat(events.get(0).getPayload())
+                  .containsEntry("workflowRef", "run-audit-missing-workflow-ref");
+            });
+  }
+
+  private List<AuditEventEntity> eventsFor(String resourceId, String action) {
+    return auditEventRepository.findAll().stream()
+        .filter(
+            event -> resourceId.equals(event.getResourceId()) && action.equals(event.getAction()))
+        .toList();
+  }
+
+  private String createWorkspace(String name) {
+    WorkspaceRequest request = new WorkspaceRequest();
+    request.setName(name);
+    request.setDisplayName(name);
+    request.setQuotas(new Quotas());
+    return workspaceService.create(request).getName();
+  }
+
+  private static WorkflowSubmitRequest manualRequest() {
+    WorkflowSubmitRequest request = new WorkflowSubmitRequest();
+    request.setTrigger(TriggerEnum.manual);
+    return request;
+  }
+
+  private static SettingConfig config(String key, String value) {
+    SettingConfig config = new SettingConfig();
+    config.setKey(key);
+    config.setValue(value);
+    return config;
+  }
+}

--- a/service-core/src/test/java/io/boomerang/workflow/StandaloneQuotaConcurrentSubmitTest.java
+++ b/service-core/src/test/java/io/boomerang/workflow/StandaloneQuotaConcurrentSubmitTest.java
@@ -1,0 +1,204 @@
+package io.boomerang.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.boomerang.common.entity.WorkflowRunEntity;
+import io.boomerang.common.enums.RunPhase;
+import io.boomerang.common.enums.TriggerEnum;
+import io.boomerang.common.error.BoomerangException;
+import io.boomerang.common.model.WorkflowSubmitRequest;
+import io.boomerang.core.security.enums.AuthScope;
+import io.boomerang.core.security.enums.PermissionScope;
+import io.boomerang.core.security.model.ResolvedPermissions;
+import io.boomerang.core.model.Token;
+import io.boomerang.engine.AbstractEngineIntegrationTest;
+import io.boomerang.workspace.WorkspaceService;
+import io.boomerang.workspace.model.Quotas;
+import io.boomerang.workspace.model.WorkspaceRequest;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * A burst of simultaneous submits must not admit more WorkflowRuns than the workspace quota
+ * allows (boomerang-io/flow#347): the quota check is a read-then-insert, so every racer can read
+ * a count below the limit and all of them pass. Each test fires one burst against a quota of one
+ * and asserts on the resulting WorkflowRun documents - the ground truth a racy check would
+ * over-populate.
+ */
+class StandaloneQuotaConcurrentSubmitTest extends AbstractEngineIntegrationTest {
+
+  private static final String QUOTA_FEATURE = "workspaceQuotas";
+
+  private static final String TASK_SLUG = "quota-burst-test-task";
+
+  private static final int BURST = 8;
+
+  @Autowired private WorkflowService workflowService;
+  @Autowired private WorkspaceService workspaceService;
+
+  @BeforeEach
+  void seedFixtures() {
+    seedRelationshipRoot();
+    seedTeamQuotaSettings();
+    seedTaskSettings();
+    seedGlobalTask(TASK_SLUG);
+    setFeatureSetting("globalParameters", false);
+    setFeatureSetting("workspaceParameters", false);
+    setFeatureSetting(QUOTA_FEATURE, false);
+  }
+
+  @AfterEach
+  void resetQuotaFeature() {
+    // Shared Testcontainers Mongo: leave the feature off, the state the other test classes seed.
+    setFeatureSetting(QUOTA_FEATURE, false);
+  }
+
+  @Test
+  void aSubmitBurstCannotExceedTheMonthlyRunQuota() throws Exception {
+    Quotas quotas = new Quotas();
+    quotas.setMaxWorkflowRunMonthly(1);
+    String workspace = createWorkspace("quota-burst-monthly", quotas);
+    String workflow = "quota-burst-monthly-workflow";
+    workflowService.create(workspace, runnableWorkflow(workflow, TASK_SLUG));
+    setFeatureSetting(QUOTA_FEATURE, true);
+
+    int admitted = submitBurst(workspace, workflow);
+
+    assertTrue(
+        admitted <= 1, "monthly quota of 1 admitted " + admitted + " of " + BURST + " submits");
+    // Simultaneous racers may all withdraw (each counted the others), leaving the slot free -
+    // the guarantee is that the limit is never over-filled. A follow-up submit fills exactly
+    // the remaining slot, and one more is refused.
+    if (admitted == 0) {
+      workflowService.submit(workspace, workflow, manualRequest(), false);
+    }
+    BoomerangException refused =
+        assertThrows(
+            BoomerangException.class,
+            () -> workflowService.submit(workspace, workflow, manualRequest(), false));
+    assertEquals("QUOTA_EXCEEDED", refused.getReason());
+    assertEquals(
+        1, persistedRuns(workspace, workflow), "WorkflowRun documents exceed the monthly quota");
+  }
+
+  @Test
+  void aSubmitBurstCannotExceedTheConcurrentRunQuota() throws Exception {
+    Quotas quotas = new Quotas();
+    quotas.setMaxConcurrentRuns(1);
+    String workspace = createWorkspace("quota-burst-concurrent", quotas);
+    String workflow = "quota-burst-concurrent-workflow";
+    workflowService.create(workspace, runnableWorkflow(workflow, TASK_SLUG));
+    setFeatureSetting(QUOTA_FEATURE, true);
+
+    int admitted = submitBurst(workspace, workflow);
+
+    // Nothing here starts or finishes a run, so every admitted run is still in flight: the
+    // number admitted is the concurrency the quota allowed.
+    assertTrue(
+        admitted <= 1, "concurrent quota of 1 admitted " + admitted + " of " + BURST + " submits");
+    if (admitted == 0) {
+      workflowService.submit(workspace, workflow, manualRequest(), false);
+    }
+    BoomerangException refused =
+        assertThrows(
+            BoomerangException.class,
+            () -> workflowService.submit(workspace, workflow, manualRequest(), false));
+    assertEquals("QUOTA_EXCEEDED", refused.getReason());
+    assertEquals(
+        1,
+        persistedRuns(workspace, workflow),
+        "WorkflowRun documents exceed the concurrent quota");
+  }
+
+  /**
+   * Fires {@code BURST} submits released together and returns how many were admitted. A rejection
+   * counts only when it is the quota refusing (QUOTA_EXCEEDED); any other failure propagates.
+   */
+  private int submitBurst(String workspace, String workflow) throws Exception {
+    ExecutorService pool = Executors.newFixedThreadPool(BURST);
+    CountDownLatch release = new CountDownLatch(1);
+    AtomicInteger admitted = new AtomicInteger();
+    try {
+      List<Future<?>> submits =
+          java.util.stream.IntStream.range(0, BURST)
+              .<Future<?>>mapToObj(
+                  i ->
+                      pool.submit(
+                          () -> {
+                            establishThreadIdentity();
+                            release.await();
+                            try {
+                              workflowService.submit(workspace, workflow, manualRequest(), false);
+                              admitted.incrementAndGet();
+                            } catch (BoomerangException e) {
+                              assertEquals("QUOTA_EXCEEDED", e.getReason());
+                            } finally {
+                              SecurityContextHolder.clearContext();
+                            }
+                            return null;
+                          }))
+              .toList();
+      release.countDown();
+      for (Future<?> submit : submits) {
+        submit.get(60, TimeUnit.SECONDS);
+      }
+    } finally {
+      pool.shutdownNow();
+    }
+    return admitted.get();
+  }
+
+  private static WorkflowSubmitRequest manualRequest() {
+    WorkflowSubmitRequest request = new WorkflowSubmitRequest();
+    request.setTrigger(TriggerEnum.manual);
+    return request;
+  }
+
+  /** SecurityContextHolder is thread-local, so each burst thread carries its own identity. */
+  private static void establishThreadIdentity() {
+    Token principal = new Token(AuthScope.global);
+    principal.setPrincipal("quota-burst-principal");
+    principal.setPermissions(
+        List.of(new ResolvedPermissions(PermissionScope.global, "**", List.of("**/**"))));
+    UsernamePasswordAuthenticationToken authentication =
+        new UsernamePasswordAuthenticationToken(principal.getPrincipal(), null);
+    authentication.setDetails(principal);
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+  }
+
+  private long persistedRuns(String workspace, String workflow) {
+    List<String> refs =
+        relationshipService.filter(
+            io.boomerang.core.enums.RelationshipType.WORKFLOW,
+            java.util.Optional.of(List.of(workflow)),
+            java.util.Optional.of(io.boomerang.core.enums.RelationshipType.WORKSPACE),
+            java.util.Optional.of(List.of(workspace)),
+            false);
+    assertEquals(1, refs.size(), "expected exactly one workflow ref for " + workflow);
+    List<WorkflowRunEntity> runs =
+        workflowRunRepository.findByWorkflowRefAndPhaseIn(
+            refs.get(0), List.of(RunPhase.values()));
+    return runs.size();
+  }
+
+  private String createWorkspace(String name, Quotas quotas) {
+    WorkspaceRequest request = new WorkspaceRequest();
+    request.setName(name);
+    request.setDisplayName(name);
+    request.setQuotas(quotas);
+    return workspaceService.create(request).getName();
+  }
+}

--- a/service-core/src/test/java/io/boomerang/workflow/StandaloneQuotaEnforcementTest.java
+++ b/service-core/src/test/java/io/boomerang/workflow/StandaloneQuotaEnforcementTest.java
@@ -8,7 +8,11 @@ import io.boomerang.common.error.BoomerangException;
 import io.boomerang.common.model.Workflow;
 import io.boomerang.common.model.WorkflowRun;
 import io.boomerang.common.model.WorkflowSubmitRequest;
+import io.boomerang.core.audit.AuditEventRepository;
+import io.boomerang.core.entity.SettingEntity;
+import io.boomerang.core.model.SettingConfig;
 import io.boomerang.engine.AbstractEngineIntegrationTest;
+import java.util.List;
 import io.boomerang.workspace.WorkspaceService;
 import io.boomerang.workspace.model.Quotas;
 import io.boomerang.workspace.model.WorkspaceRequest;
@@ -32,6 +36,7 @@ class StandaloneQuotaEnforcementTest extends AbstractEngineIntegrationTest {
 
   @Autowired private WorkflowService workflowService;
   @Autowired private WorkspaceService workspaceService;
+  @Autowired private AuditEventRepository auditEventRepository;
 
   @BeforeEach
   void seedFixtures() {
@@ -80,6 +85,76 @@ class StandaloneQuotaEnforcementTest extends AbstractEngineIntegrationTest {
         workflowService.submit(workspace, "quota-duration-workflow", request, false);
 
     assertEquals(7L, run.getTimeout());
+  }
+
+  @Test
+  void theMonthlyRunQuotaSurvivesWorkflowDeletion() {
+    Quotas quotas = new Quotas();
+    quotas.setMaxWorkflowRunMonthly(1);
+    String workspace = createWorkspace("quota-monthly-audit", quotas);
+    workflowService.create(workspace, runnableWorkflow("quota-audit-first-workflow", TASK_SLUG));
+    setFeatureSetting(QUOTA_FEATURE, true);
+    seedAuditCapture();
+    try {
+      WorkflowSubmitRequest request = new WorkflowSubmitRequest();
+      request.setTrigger(TriggerEnum.manual);
+      WorkflowRun run =
+          workflowService.submit(workspace, "quota-audit-first-workflow", request, false);
+
+      // The run-creation audit event is written asynchronously; the quota only counts it once
+      // it has landed, so wait for it before removing the live evidence.
+      awaitEngine("run CREATE audit event")
+          .untilAsserted(
+              () ->
+                  org.junit.jupiter.api.Assertions.assertTrue(
+                      auditEventRepository.findAll().stream()
+                          .anyMatch(
+                              event ->
+                                  run.getId().equals(event.getResourceId())
+                                      && "CREATE".equals(event.getAction()))));
+
+      // Deleting the Workflow removes its relationship node, so the live count no longer sees
+      // the run - only the audit event still testifies to it.
+      workflowService.delete(workspace, "quota-audit-first-workflow");
+      workflowService.create(
+          workspace, runnableWorkflow("quota-audit-second-workflow", TASK_SLUG));
+
+      BoomerangException refused =
+          assertThrows(
+              BoomerangException.class,
+              () ->
+                  workflowService.submit(
+                      workspace, "quota-audit-second-workflow", request, false));
+      assertEquals("QUOTA_EXCEEDED", refused.getReason());
+    } finally {
+      removeAuditCapture();
+    }
+  }
+
+  private void seedAuditCapture() {
+    if (settingsRepository.findOneByKey("audit") != null) {
+      return;
+    }
+    SettingEntity settings = new SettingEntity();
+    settings.setKey("audit");
+    settings.setName("Audit");
+    settings.setConfig(List.of(auditConfig("enabled", "true"), auditConfig("level", "WRITE")));
+    settingsRepository.save(settings);
+  }
+
+  /** Leaves the shared database as the other test classes expect it: capture off. */
+  private void removeAuditCapture() {
+    SettingEntity settings = settingsRepository.findOneByKey("audit");
+    if (settings != null) {
+      settingsRepository.delete(settings);
+    }
+  }
+
+  private static SettingConfig auditConfig(String key, String value) {
+    SettingConfig config = new SettingConfig();
+    config.setKey(key);
+    config.setValue(value);
+    return config;
   }
 
   private String createWorkspace(String name, Quotas quotas) {

--- a/service-loader/src/main/java/io/boomerang/loader/migration/_0041__QuotaCountIndexes.java
+++ b/service-loader/src/main/java/io/boomerang/loader/migration/_0041__QuotaCountIndexes.java
@@ -1,0 +1,63 @@
+package io.boomerang.loader.migration;
+
+import static io.boomerang.loader.migration.MigrationUtils.dropIndex;
+import static io.boomerang.loader.migration.MigrationUtils.ensureIndexKeys;
+
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
+import io.boomerang.loader.CollectionNames;
+import io.flamingock.api.annotations.Apply;
+import io.flamingock.api.annotations.Change;
+import io.flamingock.api.annotations.Rollback;
+import io.flamingock.api.annotations.TargetSystem;
+import org.bson.Document;
+
+/**
+ * The {@code workflow_runs} indexes behind the quota counters. Every quota evaluation ({@code
+ * WorkspaceService.setCurrentQuotas}) issues two server-side counts via {@code
+ * WorkflowRunService.countForQuota}, both anchored on {@code workflowRef $in} - a predicate no
+ * existing index leads with ({@code _0017__RunIndexes}' {@code claim_page} leads with {@code
+ * status}; {@code _0037__SweepIndexes}' {@code workflow_ref_phase} covers {@code workflowRef} but
+ * pairs it with {@code phase}, which neither count filters beyond the prefix).
+ *
+ * <p>Both non-unique, and both created via {@link MigrationUtils#ensureIndexKeys} for the same
+ * reason as {@code _0036}: a v4 install ran with {@code auto-index-creation=true} and may already
+ * carry a Spring-named index over the same keys.
+ *
+ * <ul>
+ *   <li>{@code workflow_runs.workflow_ref_creation {workflowRef:1, creationDate:1}} - the monthly
+ *       quota count ({@code workflowRef $in} + the calendar-month {@code creationDate} range). Also
+ *       serves the insights date-window queries ({@code WorkflowRunService.insights} and the
+ *       date-bounded {@code count}), which filter {@code workflowRef $in} + {@code creationDate}.
+ *   <li>{@code workflow_runs.workflow_ref_status {workflowRef:1, status:1}} - the concurrent quota
+ *       count ({@code workflowRef $in} + {@code status $in (notstarted, ready, running, waiting)}).
+ * </ul>
+ */
+@Change(id = "0041-quota-count-indexes", author = "boomerang", transactional = false)
+@TargetSystem(id = "flow-mongodb")
+public class _0041__QuotaCountIndexes {
+
+  @Apply
+  public void execute(MongoDatabase db, CollectionNames names) {
+    String workflowRuns = names.resolve("workflow_runs");
+    ensureIndexKeys(
+        db,
+        workflowRuns,
+        "workflow_ref_creation",
+        new Document("workflowRef", 1).append("creationDate", 1),
+        new IndexOptions());
+    ensureIndexKeys(
+        db,
+        workflowRuns,
+        "workflow_ref_status",
+        new Document("workflowRef", 1).append("status", 1),
+        new IndexOptions());
+  }
+
+  @Rollback
+  public void rollback(MongoDatabase db, CollectionNames names) {
+    String workflowRuns = names.resolve("workflow_runs");
+    dropIndex(db, workflowRuns, "workflow_ref_creation");
+    dropIndex(db, workflowRuns, "workflow_ref_status");
+  }
+}

--- a/service-loader/src/test/java/io/boomerang/loader/LoaderMigrationTest.java
+++ b/service-loader/src/test/java/io/boomerang/loader/LoaderMigrationTest.java
@@ -327,6 +327,7 @@ class LoaderMigrationTest {
     assertDefinitionIndexes();
     assertRelationshipAndAuditIndexes();
     assertSweepIndexes();
+    assertQuotaCountIndexes();
     assertWorkspaceRenameApplied();
     assertV4ResidualCollectionsDropped();
     assertWorkerFlowImagesRepointed();
@@ -1374,6 +1375,15 @@ class LoaderMigrationTest {
     assertIndex("workflow_runs", "workflow_ref_phase", List.of("workflowRef", "phase"));
     assertIndex("task_runs", "claimed_sweep", List.of("phase", "claim.at"));
     assertIndex("actions", "status_sweep", List.of("status", "creationDate"));
+  }
+
+  /**
+   * {@code _0041}: the quota-count indexes. Both quota counters anchor on {@code workflowRef $in},
+   * which only {@code workflow_ref_phase} prefixes - and neither count filters {@code phase}.
+   */
+  private void assertQuotaCountIndexes() {
+    assertIndex("workflow_runs", "workflow_ref_creation", List.of("workflowRef", "creationDate"));
+    assertIndex("workflow_runs", "workflow_ref_status", List.of("workflowRef", "status"));
   }
 
   private void assertWorkspaceRenameApplied() {

--- a/specifications/data-model.md
+++ b/specifications/data-model.md
@@ -30,7 +30,7 @@ so the annotation `boomerang.io/status` is on disk as `boomerang#io/status`.
 | `approver_groups` | Named approver sets used by approval tasks | `ApproverGroupEntity` (`workspace`) |
 | `users`, `tokens`, `roles` | User accounts; hashed bearer tokens with principal, permissions, expiry; the five permission roles | `UserEntity`, `TokenEntity`, `RoleEntity` (`core`) |
 | `settings` | Instance settings grouped by `key`, each with a `config` list | `SettingEntity` (`core`) |
-| `audit` | One flat event per audited attempt: CloudEvents-style envelope (`type`, `source`, `time`, `subject`), actor (`actorId`/`actorName`/`actorType`), `workspaceId`, `action`, resource (`resourceType`/`resourceId`/`resourceName`), `outcome`, `level`, `payload`; expires by TTL | `AuditEventEntity` (`core.audit`) |
+| `audit` | One flat event per audited attempt: CloudEvents-style envelope (`type`, `source`, `time`, `subject`), actor (`actorId`/`actorName`/`actorType`), `workspaceId`, `action`, resource (`resourceType`/`resourceId`/`resourceName`), `outcome`, `level`, `payload`; run lifecycle events (`workflowrun` CREATE on admission, UPDATE on completion) ride the engine's transition listener; expires by TTL | `AuditEventEntity` (`core.audit`) |
 | `rel_nodes`, `rel_edges` | The relationship graph (schema below) | `RelationshipNodeEntity`, `RelationshipEdgeEntity` (`core`) |
 | `parameters` | Global parameters | `GlobalParamEntity` (`workflow`) |
 | `integrations`, `integration_templates` | Installed integrations and their catalogue | `IntegrationsEntity`, `IntegrationTemplateEntity` (`integrations`) |

--- a/specifications/decisions/0071-monthly-run-quotas-count-audit-events-so-deletion-cannot-reset-them.md
+++ b/specifications/decisions/0071-monthly-run-quotas-count-audit-events-so-deletion-cannot-reset-them.md
@@ -1,0 +1,40 @@
+# 0071 — Monthly run quotas count audit events so deletion cannot reset them
+
+**Status:** accepted · **Date:** 2026-09-03
+
+## Context
+
+The monthly run quota counted live `workflow_runs` documents, so deleting a Workflow (which
+removes its relationship node and, once pruned, its run documents) reset the count and freed the
+quota mid-month. The audit trail now records one `CREATE` event per WorkflowRun admission
+(`core/audit/WorkflowRunAuditBridge.java`), and those events outlive both the run documents and
+the Workflow.
+
+## Options
+
+| Option | Fits when | Cost / risk |
+| --- | --- | --- |
+| A. Keep counting live run documents | Deletion resetting the quota is acceptable | A delete/recreate loop grants unlimited monthly runs |
+| B. Count only audit events | The audit write were synchronous and guaranteed | It is async best-effort — a just-admitted run may not be audited yet, and capture can be disabled |
+| C. `max(audit count, live count)` | Both sources are individually incomplete in opposite directions | Slight over-count is impossible (max, not sum); audit-off installs degrade to A |
+
+## Decision
+
+Option C. `WorkspaceService.setCurrentQuotas` sets the monthly counter to the maximum of the
+month's `{workspaceId, action=CREATE, resourceType=workflowrun}` audit events
+(`core/audit/AuditQueryService.countRunsCreated`, served by the `workspace_time` index) and the
+month's live run documents (`workflow/WorkflowRunService.countForQuota`). The live count covers
+the async-audit race; the audit count covers deletion. The concurrent counter stays purely live —
+it measures what is running now, which deletion legitimately reduces. TaskRun transitions are not
+audited at all: their volume would dwarf the trail and no consumer (quota or insights) reads them.
+
+## Consequences
+
+- Deleting and recreating a Workflow no longer resets the monthly quota; the admit-then-recheck
+  guard inherits the same counter.
+- Audit retention is floored at 60 days (`AuditRetentionService.MIN_RETENTION_DAYS`) so the month
+  window always holds.
+- An install with audit capture disabled falls back to the live count alone — deletion resets the
+  quota there. Revisit if that becomes a support issue (the fix is forcing run-lifecycle capture).
+- Runs marked invalid before admission publish no transition and are never audited; they count
+  only while their documents live.

--- a/specifications/decisions/0072-monthly-run-quotas-count-audit-events-so-deletion-cannot-reset-them.md
+++ b/specifications/decisions/0072-monthly-run-quotas-count-audit-events-so-deletion-cannot-reset-them.md
@@ -1,4 +1,4 @@
-# 0071 — Monthly run quotas count audit events so deletion cannot reset them
+# 0072 — Monthly run quotas count audit events so deletion cannot reset them
 
 **Status:** accepted · **Date:** 2026-09-03
 

--- a/specifications/decisions/README.md
+++ b/specifications/decisions/README.md
@@ -56,3 +56,4 @@ things by name, not by code.
 | 0068 | [An empty workflow task parameter value is valid; required-ness is the task's run-time concern](0068-an-empty-workflow-task-parameter-value-is-valid.md) | accepted | 2026-09-02 |
 | 0069 | [Submit starts the run by default; parking is the explicit opt-out](0069-submit-starts-the-run-by-default.md) | accepted | 2026-09-02 |
 | 0070 | [Audit is flat per-event documents captured by annotation, with levels](0070-audit-is-flat-per-event-documents-captured-by-annotation.md) | accepted | 2026-09-03 |
+| 0071 | [Monthly run quotas count audit events so deletion cannot reset them](0071-monthly-run-quotas-count-audit-events-so-deletion-cannot-reset-them.md) | accepted | 2026-09-03 |

--- a/specifications/decisions/README.md
+++ b/specifications/decisions/README.md
@@ -56,4 +56,4 @@ things by name, not by code.
 | 0068 | [An empty workflow task parameter value is valid; required-ness is the task's run-time concern](0068-an-empty-workflow-task-parameter-value-is-valid.md) | accepted | 2026-09-02 |
 | 0069 | [Submit starts the run by default; parking is the explicit opt-out](0069-submit-starts-the-run-by-default.md) | accepted | 2026-09-02 |
 | 0070 | [Audit is flat per-event documents captured by annotation, with levels](0070-audit-is-flat-per-event-documents-captured-by-annotation.md) | accepted | 2026-09-03 |
-| 0071 | [Monthly run quotas count audit events so deletion cannot reset them](0071-monthly-run-quotas-count-audit-events-so-deletion-cannot-reset-them.md) | accepted | 2026-09-03 |
+| 0072 | [Monthly run quotas count audit events so deletion cannot reset them](0072-monthly-run-quotas-count-audit-events-so-deletion-cannot-reset-them.md) | accepted | 2026-09-03 |

--- a/specifications/execution-model.md
+++ b/specifications/execution-model.md
@@ -129,7 +129,11 @@ call at any time; the watcher and resume both use it. Transition handlers follow
 
 ## Outbound events: the transactional outbox
 
-CAS winners publish an in-process `TaskRunTransition`/`WorkflowRunTransition` event (`engine/model/*.java`). When
+CAS winners publish an in-process `TaskRunTransition`/`WorkflowRunTransition` event (`engine/model/*.java`).
+`WorkflowRunAuditBridge` consumes the WorkflowRun stream (`core/audit/WorkflowRunAuditBridge.java`): the run's first
+status change records a CREATE audit event and reaching the completed phase records an UPDATE event carrying the
+terminal status and duration — the events the monthly run quota and the workspace insights read. TaskRun transitions
+are not audited (volume; no consumer reads them). Emission is best-effort and never fails the transition. When
 `flow.events.sink.enabled=true` (default `false`, `service-core/src/main/resources/application.properties:38`),
 `CloudEventsBridge` inserts one `events_outbox` row per externally visible status change (`event/CloudEventsBridge.java:32-76`)
 and `OutboxDispatcher` drains it every 5 s on every instance, delivering at least once, marking rows `sent` by CAS,

--- a/specifications/performance.md
+++ b/specifications/performance.md
@@ -109,6 +109,19 @@ and enforcement additionally requires the `features.workspaceQuotas` setting (`w
 | `max.workflow.storage`, `max.workflowrun.storage` | Run submit (workspace size ≤ quota, else `QUOTA_EXCEEDED`) | `WorkflowService.java:445-491,921-950` |
 | `max.workflowrun.duration` | Run submit, as the ceiling on the requested timeout | `WorkflowService.java:224-234` |
 
+The two run counters come from different sources (decision 0071). Concurrent = the live count of
+non-terminal runs (`notstarted`/`ready`/`running`/`waiting`) over the workspace's Workflows
+(`workflow/WorkflowRunService.countForQuota`, the `workflow_ref_status` index) — what is running
+now, which deletion legitimately reduces. Monthly = `max(audit count, live count)`: the month's
+`{workspaceId, action=CREATE, resourceType=workflowrun}` audit events
+(`core/audit/AuditQueryService.countRunsCreated`, the `workspace_time` index) versus the month's
+live run documents (the `workflow_ref_creation` index). The max is deliberate — the audit write is
+async best-effort, so a just-admitted run may not be audited yet (the live count covers that
+race), while a deleted Workflow's runs leave the live count (the audit count covers deletion).
+Submit re-checks the same counters after admitting the run, so a burst cannot over-fill a limit
+(`WorkflowService.guardQuotasAfterAdmission`). Audit retention is floored at 60 days so the month
+window always holds (`core/audit/AuditRetentionService.java`).
+
 ## Payload caps
 
 Two byte caps bound what every executor must carry (`application.properties:149-155`): resolved params


### PR DESCRIPTION
Run-lifecycle audit events, an audit-backed monthly run quota, and the two matching UI notes.

## Stack

Merge order: #415 (`fix/347-quota-concurrency`) → #417 (`feat/audit-events`) → this PR. The branch is cut from `feat/audit-events` with `fix/347-quota-concurrency` merged in, and targets `feat/audit-events`.

## What it does

**Run-lifecycle audit events.** `core/audit/WorkflowRunAuditBridge` consumes the engine's `WorkflowRunTransition` events: the run's first status change (admission, `notstarted → ready`) records a `CREATE` event and reaching the `completed` phase records an `UPDATE` event carrying the terminal status and duration. The owning workspace resolves from the Workflow's `HAS_WORKFLOW` parent edge (the `ActionService` pattern); an unresolvable owner audits with a null `workspaceId` and logs — the transition never fails. The actor is the current principal when present, else the system sentinel. TaskRun transitions are deliberately not audited (volume; no consumer reads them). `AuditEventEmitter.emitAs` (explicit actor + payload map) and an `AuditRecord.payload` component carry the run facts (`workflowRef`, `workflowName`, `status`, `phase`, `duration`) that `InsightsService` reads; the insights rollup now collapses the events per run so a completed run is one summary, not two.

**Monthly quota from audit.** `WorkspaceService.setCurrentQuotas` sets the monthly counter to `max(auditCount, liveMonthlyCount)`:

- `auditCount` = the month's `{workspaceId, action: CREATE, resourceType: workflowrun, time in [monthStart, nextMonth)}` events (`AuditQueryService.countRunsCreated`, served by the `workspace_time` index);
- `liveMonthlyCount` = #415's `countForQuota` month window.

The `max` is deliberate: the audit write is async best-effort, so a just-admitted run may not be audited yet (the live count covers the race), while a deleted Workflow's runs leave the live count (the audit count covers deletion — including once pruning hard-deletes documents). The concurrent counter stays #415's live non-terminal count, and the admit-then-recheck guard reads the same counters so it inherits the behaviour with #415's `>=`/`>` semantics unchanged. Audit retention is already floored at 60 days, so the month window always holds.

**UI notes.** The monthly quota card notes that counts include Workflows and runs deleted since; the Insights header notes that insights are drawn from the audit trail and therefore also include deleted Workflows and runs (on this stack `/workspace/{workspace}/insights` is served by the audit-backed `InsightsService`, so a "live data only" caveat would be untrue).

**Specs.** `performance.md` Quotas and `execution-model.md` updated; decision `0071 — Monthly run quotas count audit events so deletion cannot reset them` (0070 was taken by the audit engine).

## Tests

- `WorkflowRunAuditBridgeTest` — CREATE emission with workspace ownership, terminal UPDATE with status/duration payload, unresolvable-workspace path.
- `StandaloneQuotaEnforcementTest.theMonthlyRunQuotaSurvivesWorkflowDeletion` — submit to the limit, delete the Workflow, recreate, submit again: still refused within the month.
- `AuditEventWriterTest` — payload merge onto the flat event.
- client-web: Insights and WorkspaceDetailed specs assert the new notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCX7rbFpsorX5jpz6NJZP1
