### PR TITLE
perf(core): positive-only token lookup cache so validate + get cost one read

### DIFF
--- a/service-core/pom.xml
+++ b/service-core/pom.xml
@@ -87,6 +87,10 @@
             <artifactId>spring-context-support</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>

--- a/service-core/src/main/java/io/boomerang/core/TokenService.java
+++ b/service-core/src/main/java/io/boomerang/core/TokenService.java
@@ -15,6 +15,7 @@ import io.boomerang.core.repository.TokenRepository;
 import io.boomerang.common.error.BoomerangError;
 import io.boomerang.common.error.BoomerangException;
 import io.boomerang.core.security.IdentityService;
+import io.boomerang.core.security.TokenLookupCache;
 import io.boomerang.core.security.enums.AuthScope;
 import io.boomerang.core.security.enums.PermissionAction;
 import io.boomerang.core.security.enums.PermissionResource;
@@ -77,6 +78,7 @@ public class TokenService {
   private final RelationshipService relationshipService;
   private final MongoTemplate mongoTemplate;
   private final IdentityService identityService;
+  private final TokenLookupCache lookupCache;
 
   public TokenService(
       TokenRepository tokenRepository,
@@ -84,13 +86,15 @@ public class TokenService {
       RoleRepository roleRepository,
       RelationshipService relationshipService,
       MongoTemplate mongoTemplate,
-      IdentityService identityService) {
+      IdentityService identityService,
+      TokenLookupCache lookupCache) {
     this.tokenRepository = tokenRepository;
     this.userService = userService;
     this.roleRepository = roleRepository;
     this.relationshipService = relationshipService;
     this.mongoTemplate = mongoTemplate;
     this.identityService = identityService;
+    this.lookupCache = lookupCache;
   }
 
   /*
@@ -392,19 +396,30 @@ public class TokenService {
   }
 
   public boolean validate(String token) {
-    LOGGER.debug("Token Validation - token: " + token);
-    String hash = hashString(token);
-    LOGGER.debug("Token Validation - hash: " + hash);
-    Optional<TokenEntity> tokenEntityOptional = this.tokenRepository.findByToken(hash);
-    if (tokenEntityOptional.isPresent()) {
-      TokenEntity tokenEntity = tokenEntityOptional.get();
-      if (isValid(tokenEntity.getExpirationDate())) {
-        LOGGER.debug("Token Validation - valid");
-        return true;
+    boolean valid = lookup(token).filter(te -> isValid(te.getExpirationDate())).isPresent();
+    LOGGER.debug("Token Validation - " + (valid ? "valid" : "not valid"));
+    return valid;
+  }
+
+  /**
+   * Resolve a raw token to its stored entity through {@link TokenLookupCache}: a hit is served
+   * from memory (evicted first if it has since expired, but still returned so callers see the same
+   * entity they would have read), a miss goes to the repository and is cached only when present
+   * and unexpired. Every read path that starts from a raw token goes through here, so {@code
+   * validate} followed by {@code get} costs one repository read.
+   */
+  private Optional<TokenEntity> lookup(String rawToken) {
+    String hash = hashString(rawToken);
+    TokenEntity cached = lookupCache.get(hash);
+    if (cached != null) {
+      if (!isValid(cached.getExpirationDate())) {
+        lookupCache.evict(hash);
       }
+      return Optional.of(cached);
     }
-    LOGGER.debug("Token Validation - not valid");
-    return false;
+    Optional<TokenEntity> found = tokenRepository.findByToken(hash);
+    found.filter(te -> isValid(te.getExpirationDate())).ifPresent(te -> lookupCache.put(hash, te));
+    return found;
   }
 
   /**
@@ -416,8 +431,7 @@ public class TokenService {
    * before reaching this (Mongo) lookup.
    */
   public Optional<TokenEntity> validateActorToken(String rawToken) {
-    return tokenRepository
-        .findByToken(hashString(rawToken))
+    return lookup(rawToken)
         .filter(te -> isValid(te.getExpirationDate()))
         .filter(te -> te.getActorKind() != null)
         .filter(te -> AuthScope.global.equals(te.getType()));
@@ -442,17 +456,19 @@ public class TokenService {
   }
 
   public boolean delete(String id) {
-    Optional<TokenEntity> tokenEntityOptional = this.tokenRepository.findById(id);
-    if (tokenEntityOptional.isPresent()) {
-      TokenEntity tokenEntity = tokenEntityOptional.get();
-      this.tokenRepository.delete(tokenEntity);
-      return true;
+    TokenEntity tokenEntity = this.tokenRepository.findById(id).orElse(null);
+    if (tokenEntity == null) {
+      return false;
     }
-    return false;
+    this.tokenRepository.delete(tokenEntity);
+    lookupCache.evict(tokenEntity.getToken());
+    return true;
   }
 
+  /** Revoke every token of {@code principal}; the hashes are not in hand, so the whole cache goes. */
   public void deleteAllForPrincipal(String principal) {
     this.tokenRepository.deleteAllByPrincipal(principal);
+    lookupCache.evictAll();
   }
 
   public Page<Token> query(
@@ -522,16 +538,14 @@ public class TokenService {
   }
 
   public Token get(String token) {
-    String hash = hashString(token);
-    Optional<TokenEntity> tokenEntityOptional = this.tokenRepository.findByToken(hash);
-    if (tokenEntityOptional.isPresent()) {
-      TokenEntity tokenEntity = tokenEntityOptional.get();
-      Token response = new Token();
-      response.setValid(isValid(tokenEntity.getExpirationDate()));
-      BeanUtils.copyProperties(tokenEntity, response);
-      return response;
+    TokenEntity tokenEntity = lookup(token).orElse(null);
+    if (tokenEntity == null) {
+      return null;
     }
-    return null;
+    Token response = new Token();
+    response.setValid(isValid(tokenEntity.getExpirationDate()));
+    BeanUtils.copyProperties(tokenEntity, response);
+    return response;
   }
 
   /*

--- a/service-core/src/main/java/io/boomerang/core/security/TokenLookupCache.java
+++ b/service-core/src/main/java/io/boomerang/core/security/TokenLookupCache.java
@@ -1,0 +1,55 @@
+package io.boomerang.core.security;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.boomerang.core.entity.TokenEntity;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Positive-only, per-instance cache of validated tokens keyed by the stored SHA-256 hash, so the
+ * authentication path resolves a bearer with one repository read per TTL instead of one per call.
+ * Only entities that were present and unexpired are ever stored - misses are never cached, so an
+ * invalid-token flood cannot fill the map - and callers re-check {@code expirationDate} on every
+ * hit because expiry is a property of the token, not of the cache. Eviction is per instance:
+ * another instance keeps serving a revoked token until its own entry ages out (the TTL).
+ */
+@Component
+public class TokenLookupCache {
+
+  private final boolean enabled;
+  private final Cache<String, TokenEntity> cache;
+
+  public TokenLookupCache(
+      @Value("${flow.security.token-cache.enabled:true}") boolean enabled,
+      @Value("${flow.security.token-cache.ttl:60s}") Duration ttl,
+      @Value("${flow.security.token-cache.max-size:10000}") long maxSize) {
+    this.enabled = enabled;
+    this.cache = Caffeine.newBuilder().expireAfterWrite(ttl).maximumSize(maxSize).build();
+  }
+
+  /** Return the cached entity for {@code hash}, or null when absent, aged out, or disabled. */
+  public TokenEntity get(String hash) {
+    return (enabled ? cache.getIfPresent(hash) : null);
+  }
+
+  /** Remember a validated entity under its hash; a no-op when disabled. */
+  public void put(String hash, TokenEntity entity) {
+    if (enabled) {
+      cache.put(hash, entity);
+    }
+  }
+
+  /** Forget one hash - called on every write that changes a token's validity or grants. */
+  public void evict(String hash) {
+    if (hash != null) {
+      cache.invalidate(hash);
+    }
+  }
+
+  /** Forget every entry - for bulk revocations where the affected hashes are not in hand. */
+  public void evictAll() {
+    cache.invalidateAll();
+  }
+}

--- a/service-core/src/main/resources/application.properties
+++ b/service-core/src/main/resources/application.properties
@@ -18,6 +18,11 @@ flow.mode=standalone
 # engine=false). Leave it unset to take the mode-derived default - the product (standalone) boots
 # secured by default.
 # flow.security.enabled=
+# Per-instance cache of validated bearer tokens keyed by hash (TokenLookupCache): one Mongo read per
+# token per TTL; revoke evicts locally only, so another instance may honour a revoked token for up to ttl.
+flow.security.token-cache.enabled=true
+flow.security.token-cache.ttl=60s
+flow.security.token-cache.max-size=10000
 # Quotas
 # flow.quotas.enabled switches the workspace quota subsystem on/off; its default derives from
 # flow.mode (standalone=true, engine=false) because every quota lives on workspace.WorkspaceService,

--- a/service-core/src/test/java/io/boomerang/core/TokenServiceLookupCacheTest.java
+++ b/service-core/src/test/java/io/boomerang/core/TokenServiceLookupCacheTest.java
@@ -1,0 +1,178 @@
+package io.boomerang.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.boomerang.core.entity.TokenEntity;
+import io.boomerang.core.repository.RoleRepository;
+import io.boomerang.core.repository.TokenRepository;
+import io.boomerang.core.security.IdentityService;
+import io.boomerang.core.security.TokenLookupCache;
+import io.boomerang.core.security.enums.AuthScope;
+import io.boomerang.core.security.enums.TokenActorKind;
+import java.time.Duration;
+import java.util.Date;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+/**
+ * The token lookup cache in front of {@code TokenRepository.findByToken}: the authentication
+ * filter's {@code validate} + {@code get} pair costs one repository read, misses are never
+ * cached, revocation evicts, an expired token is refused even while cached, and the switch turns
+ * the cache into a pass-through.
+ */
+@ExtendWith(MockitoExtension.class)
+class TokenServiceLookupCacheTest {
+
+  private static final String RAW = "bfu_11111111-2222-3333-4444-555555555555";
+
+  @Mock private TokenRepository tokenRepository;
+  @Mock private UserService userService;
+  @Mock private RoleRepository roleRepository;
+  @Mock private RelationshipService relationshipService;
+  @Mock private MongoTemplate mongoTemplate;
+  @Mock private IdentityService identityService;
+
+  private TokenService tokenService;
+  private String hash;
+  private TokenEntity stored;
+
+  @BeforeEach
+  void setUp() {
+    tokenService = service(new TokenLookupCache(true, Duration.ofSeconds(60), 10_000));
+    hash = tokenService.hashString(RAW);
+    stored = new TokenEntity();
+    stored.setId("token-1");
+    stored.setToken(hash);
+    stored.setType(AuthScope.user);
+    stored.setPrincipal("user-1");
+    stored.setExpirationDate(new Date(System.currentTimeMillis() + 60_000));
+  }
+
+  private TokenService service(TokenLookupCache cache) {
+    return new TokenService(
+        tokenRepository,
+        userService,
+        roleRepository,
+        relationshipService,
+        mongoTemplate,
+        identityService,
+        cache);
+  }
+
+  @Test
+  void validateThenGetReadsTheRepositoryOnce() {
+    when(tokenRepository.findByToken(hash)).thenReturn(Optional.of(stored));
+
+    assertThat(tokenService.validate(RAW)).isTrue();
+    assertThat(tokenService.get(RAW)).isNotNull().extracting("principal").isEqualTo("user-1");
+    assertThat(tokenService.validate(RAW)).isTrue();
+
+    verify(tokenRepository, times(1)).findByToken(hash);
+  }
+
+  @Test
+  void anActorTokenIsServedFromTheSameCacheEntry() {
+    stored.setType(AuthScope.global);
+    stored.setActorKind(TokenActorKind.SERVICE);
+    when(tokenRepository.findByToken(hash)).thenReturn(Optional.of(stored));
+
+    assertThat(tokenService.validate(RAW)).isTrue();
+    assertThat(tokenService.validateActorToken(RAW)).contains(stored);
+
+    verify(tokenRepository, times(1)).findByToken(hash);
+  }
+
+  @Test
+  void anUnknownTokenIsLookedUpEveryTime() {
+    when(tokenRepository.findByToken(anyString())).thenReturn(Optional.empty());
+
+    assertThat(tokenService.validate(RAW)).isFalse();
+    assertThat(tokenService.get(RAW)).isNull();
+    assertThat(tokenService.validate("bfu_unknown")).isFalse();
+
+    verify(tokenRepository, times(3)).findByToken(anyString());
+  }
+
+  @Test
+  void anExpiredTokenReadFromTheRepositoryIsNotCached() {
+    stored.setExpirationDate(new Date(System.currentTimeMillis() - 1_000));
+    when(tokenRepository.findByToken(hash)).thenReturn(Optional.of(stored));
+
+    assertThat(tokenService.validate(RAW)).isFalse();
+    assertThat(tokenService.validate(RAW)).isFalse();
+
+    verify(tokenRepository, times(2)).findByToken(hash);
+  }
+
+  @Test
+  void deleteEvictsSoTheNextLookupMisses() {
+    when(tokenRepository.findByToken(hash)).thenReturn(Optional.of(stored), Optional.empty());
+    when(tokenRepository.findById("token-1")).thenReturn(Optional.of(stored));
+
+    assertThat(tokenService.validate(RAW)).isTrue();
+    assertThat(tokenService.delete("token-1")).isTrue();
+    assertThat(tokenService.validate(RAW)).isFalse();
+
+    verify(tokenRepository).delete(stored);
+    verify(tokenRepository, times(2)).findByToken(hash);
+  }
+
+  @Test
+  void deleteAllForPrincipalEvictsSoTheNextLookupMisses() {
+    when(tokenRepository.findByToken(hash)).thenReturn(Optional.of(stored), Optional.empty());
+
+    assertThat(tokenService.validate(RAW)).isTrue();
+    tokenService.deleteAllForPrincipal("user-1");
+    assertThat(tokenService.validate(RAW)).isFalse();
+
+    verify(tokenRepository).deleteAllByPrincipal("user-1");
+    verify(tokenRepository, times(2)).findByToken(hash);
+  }
+
+  @Test
+  void aCachedTokenThatHasSinceExpiredIsRejected() {
+    when(tokenRepository.findByToken(hash)).thenReturn(Optional.of(stored));
+    assertThat(tokenService.validate(RAW)).isTrue();
+
+    // Expiry is a property of the token, so the cached entity is re-checked on every hit.
+    stored.setExpirationDate(new Date(System.currentTimeMillis() - 1_000));
+
+    assertThat(tokenService.validate(RAW)).isFalse();
+    assertThat(tokenService.get(RAW).isValid()).isFalse();
+    assertThat(tokenService.validateActorToken(RAW)).isEmpty();
+    verify(tokenRepository, never()).delete(stored);
+  }
+
+  @Test
+  void touchLastUsedKeepsTheEntryCached() {
+    when(tokenRepository.findByToken(hash)).thenReturn(Optional.of(stored));
+
+    assertThat(tokenService.validate(RAW)).isTrue();
+    tokenService.touchLastUsed(stored);
+    assertThat(tokenService.validate(RAW)).isTrue();
+
+    verify(tokenRepository).save(stored);
+    verify(tokenRepository, times(1)).findByToken(hash);
+  }
+
+  @Test
+  void aDisabledCacheReadsTheRepositoryOnEveryCall() {
+    tokenService = service(new TokenLookupCache(false, Duration.ofSeconds(60), 10_000));
+    when(tokenRepository.findByToken(hash)).thenReturn(Optional.of(stored));
+
+    assertThat(tokenService.validate(RAW)).isTrue();
+    assertThat(tokenService.get(RAW)).isNotNull();
+
+    verify(tokenRepository, times(2)).findByToken(hash);
+  }
+}

--- a/service-core/src/test/java/io/boomerang/core/TokenServiceLookupCacheWiringTest.java
+++ b/service-core/src/test/java/io/boomerang/core/TokenServiceLookupCacheWiringTest.java
@@ -1,0 +1,51 @@
+package io.boomerang.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.boomerang.core.model.Token;
+import io.boomerang.core.model.TokenCreateRequest;
+import io.boomerang.core.model.TokenCreateResponse;
+import io.boomerang.core.repository.TokenRepository;
+import io.boomerang.core.security.TokenLookupCache;
+import io.boomerang.core.security.enums.AuthScope;
+import io.boomerang.engine.AbstractEngineIntegrationTest;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * The lookup cache as wired into the Spring context against a real Mongo: a minted token
+ * validates, is cached under its hash, and revocation through {@code TokenService.delete} both
+ * removes the document and evicts the entry so the very next validation is refused.
+ */
+class TokenServiceLookupCacheWiringTest extends AbstractEngineIntegrationTest {
+
+  @Autowired private TokenService tokenService;
+  @Autowired private TokenRepository tokenRepository;
+  @Autowired private TokenLookupCache lookupCache;
+
+  @Test
+  void aRevokedTokenIsRefusedOnTheNextRequest() {
+    TokenCreateRequest request = new TokenCreateRequest();
+    request.setType(AuthScope.key);
+    request.setName("cache-wiring-" + UUID.randomUUID());
+    request.setPrincipal("workflow-" + UUID.randomUUID());
+    request.setPermissions(List.of("workflow/read"));
+    TokenCreateResponse created = tokenService.create(request);
+    String raw = created.getToken();
+    String hash = tokenService.hashString(raw);
+
+    assertThat(tokenService.validate(raw)).isTrue();
+    assertThat(lookupCache.get(hash)).isNotNull();
+    Token token = tokenService.get(raw);
+    assertThat(token.getPrincipal()).isEqualTo(request.getPrincipal());
+
+    assertThat(tokenService.delete(created.getId())).isTrue();
+
+    assertThat(lookupCache.get(hash)).isNull();
+    assertThat(tokenRepository.findByToken(hash)).isEmpty();
+    assertThat(tokenService.validate(raw)).isFalse();
+    assertThat(tokenService.get(raw)).isNull();
+  }
+}

--- a/service-core/src/test/java/io/boomerang/core/TokenServiceSessionTest.java
+++ b/service-core/src/test/java/io/boomerang/core/TokenServiceSessionTest.java
@@ -17,6 +17,7 @@ import java.time.Duration;
 import io.boomerang.core.repository.RoleRepository;
 import io.boomerang.core.repository.TokenRepository;
 import io.boomerang.core.security.IdentityService;
+import io.boomerang.core.security.TokenLookupCache;
 import io.boomerang.core.security.enums.AuthScope;
 import java.util.Map;
 import java.util.Optional;
@@ -52,7 +53,13 @@ class TokenServiceSessionTest {
   void setUp() {
     tokenService =
         new TokenService(
-            tokenRepository, userService, roleRepository, relationshipService, mongoTemplate, identityService);
+            tokenRepository,
+            userService,
+            roleRepository,
+            relationshipService,
+            mongoTemplate,
+            identityService,
+            new TokenLookupCache(true, Duration.ofSeconds(60), 10_000));
     ReflectionTestUtils.setField(tokenService, "MAX_SESSION_TOKEN_DURATION", 8);
     when(tokenRepository.save(any(TokenEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
     when(relationshipService.roles(any())).thenReturn(Map.of());

--- a/service-core/src/test/java/io/boomerang/core/TokenServiceTest.java
+++ b/service-core/src/test/java/io/boomerang/core/TokenServiceTest.java
@@ -16,10 +16,12 @@ import io.boomerang.core.model.TokenCreateResponse;
 import io.boomerang.core.repository.RoleRepository;
 import io.boomerang.core.repository.TokenRepository;
 import io.boomerang.core.security.IdentityService;
+import io.boomerang.core.security.TokenLookupCache;
 import io.boomerang.core.security.enums.AuthScope;
 import io.boomerang.core.security.enums.PermissionScope;
 import io.boomerang.core.security.enums.TokenActorKind;
 import io.boomerang.core.security.model.ResolvedPermissions;
+import java.time.Duration;
 import java.util.List;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,7 +61,8 @@ class TokenServiceTest {
             roleRepository,
             relationshipService,
             mongoTemplate,
-            identityService);
+            identityService,
+            new TokenLookupCache(true, Duration.ofSeconds(60), 10_000));
   }
 
   // =====================================================================================

--- a/specifications/authorization.md
+++ b/specifications/authorization.md
@@ -25,7 +25,7 @@ first and is independent of this switch — see "Dispatcher endpoints".
 
 | Order | Source | Handled by | Result |
 | --- | --- | --- | --- |
-| 1 | `Authorization: Bearer bf?_…` (a Flow-minted token) | `getTokenAuthentication` (`:271-286`) | SHA-256 hash lookup in `tokens`, expiry check (`core/TokenService.java:403-417`) |
+| 1 | `Authorization: Bearer bf?_…` (a Flow-minted token) | `getTokenAuthentication` (`:271-286`) | SHA-256 hash lookup in `tokens`, expiry check (`core/TokenService.java:398-423`) |
 | 1b | `Authorization: Bearer <JSON Web Token (JWT)>` (not Flow-shaped) | `getUserSessionAuthentication` (`:184-231`) | JWT is parsed for `email`/`emailAddress` and names, **not signature-verified**; a session token is minted for that email |
 | 1c | `Authorization: Basic email:password` | same method (`:232-261`) | password must equal `flow.authorization.basic.password`; session token minted for the email |
 | 2 | `x-access-token` header | `getTokenAuthentication` | as row 1 |
@@ -34,9 +34,19 @@ first and is independent of this switch — see "Dispatcher endpoints".
 | 5 | `flow_session` cookie | `getTokenAuthentication` (`:115-116,148-159`) | the opaque `bfs_` value minted by `POST /api/v2/auth/exchange` |
 
 Rows 1b, 1c and 4 mint through `TokenService.createSessionToken`, which reuses one persisted session per
-normalised email for 60 seconds per instance (`core/TokenService.java:578-605`). User creation is allowed
+normalised email for 60 seconds per instance (`core/TokenService.java:585-619`). User creation is allowed
 only on `/api/v2/profile` and the exchange path; activation only on `/api/v2/activate` and the exchange path
 (`AuthenticationFilter.java:172-182`).
+
+Rows 1, 2, 3 and 5 resolve the bearer through `TokenLookupCache` (`core/security/TokenLookupCache.java`), a
+per-instance Caffeine cache keyed by the stored SHA-256 hash and holding the validated `TokenEntity`, so the
+filter's `validate` followed by `get` costs one repository read (`core/TokenService.java:411-423`). Only a
+present, unexpired entity is cached - misses are never cached - and the entity's `expirationDate` is re-checked
+on every hit. Entries live 60 seconds and the cache holds at most 10 000 (`flow.security.token-cache.ttl`,
+`flow.security.token-cache.max-size`, `flow.security.token-cache.enabled`, `application.properties:23-25`).
+`TokenService.delete` evicts the token's hash and `deleteAllForPrincipal` flushes the cache
+(`core/TokenService.java:458-472`); `touchLastUsed` does not evict. Eviction is per instance: after a revoke on
+one instance, another instance MAY still honour the token until its own entry ages out, at most the TTL.
 
 No identity → `AUTH_REQUIRED` (HTTP 401) via `DelegatedAuthenticationEntryPoint` (`:128-132`), except on
 `/api/v2/auth/exchange`, which continues so the controller can verify an OpenID Connect (OIDC) id_token itself
@@ -60,17 +70,17 @@ server routes (`client-web/app/Features/Auth/`), so the id_token never reaches t
 ## Token kinds
 
 `AuthScope` is the token **class**; `TokenActorKind` is an orthogonal badge for machine tokens; `PermissionScope`
-(`global` | `workspace`) is the scope of each grant and is always derived server-side (`core/TokenService.java:170-199`).
+(`global` | `workspace`) is the scope of each grant and is always derived server-side (`core/TokenService.java:174-203`).
 
 | `AuthScope` | Prefix | Holder | Grants | How it is minted |
 | --- | --- | --- | --- | --- |
-| `session` | `bfs_` | a signed-in human | re-resolved from the user's type and memberships (`resolvePermissionsForUser`, `TokenService.java:704-724`) | only by `AuthenticationFilter`/the exchange; `POST /api/v2/token` rejects it (`:105-106`) |
-| `user` | `bfu_` | a human's long-lived personal token | copied from that user's workspace roles (`:174-184`) | `POST /api/v2/token` |
-| `key` | `bfk_` | a machine — service, AI agent, or a workflow's own scheduler credential (`actorKind`) | always `workspace`-scoped; a `global` grant is refused (`:375-381`) | `POST /api/v2/token`; `createWorkflowSchedulerToken` for workflows (`:757-769`) |
-| `global` | `bfg_` | platform admin or the dispatcher (`actorKind=SERVICE`) | one `global` grant | `POST /api/v2/token`, and only by a caller who already holds a `global` grant (`:132-134`) |
+| `session` | `bfs_` | a signed-in human | re-resolved from the user's type and memberships (`resolvePermissionsForUser`, `TokenService.java:711-731`) | only by `AuthenticationFilter`/the exchange; `POST /api/v2/token` rejects it (`:109-110`) |
+| `user` | `bfu_` | a human's long-lived personal token | copied from that user's workspace roles (`:178-188`) | `POST /api/v2/token` |
+| `key` | `bfk_` | a machine — service, AI agent, or a workflow's own scheduler credential (`actorKind`) | always `workspace`-scoped; a `global` grant is refused (`:379-385`) | `POST /api/v2/token`; `createWorkflowSchedulerToken` for workflows (`:764-781`) |
+| `global` | `bfg_` | platform admin or the dispatcher (`actorKind=SERVICE`) | one `global` grant | `POST /api/v2/token`, and only by a caller who already holds a `global` grant (`:136-138`) |
 
 `TokenActorKind` is `SERVICE`, `AGENT` or `WORKFLOW` (`core/security/enums/TokenActorKind.java:22-26`), null on
-human tokens. Only the SHA-256 hash of a raw token is stored (`TokenService.java:384-387`), and a bearer that does
+human tokens. Only the SHA-256 hash of a raw token is stored (`TokenService.java:388-391`), and a bearer that does
 not match `^bf[gkus]_.+` is rejected before any database lookup (`core/enums/TokenTypePrefix.java:35`).
 
 Seeded roles (`service-loader/src/main/resources/seed/roles.json`): global `admin` (`**/**`) and `operator`
@@ -139,7 +149,7 @@ segment is not `system` (`core/security/EngineWorkspaceInterceptor.java:37-44`, 
 `/api/v1/dispatcher/**` is guarded by `DispatcherAuthFilter` regardless of `flow.security.enabled`
 (`dispatcher/DispatcherAuthFilter.java:54,78-105`): the bearer must be Flow-shaped, then
 `TokenService.validateActorToken` requires a stored, unexpired `global` token with a non-null `actorKind`
-(`core/TokenService.java:427-433`). `lastUsedAt` is stamped at most every 5 minutes. `flow.dispatcher.auth.enabled=false`
+(`core/TokenService.java:433-438`, read through the same lookup cache). `lastUsedAt` is stamped at most every 5 minutes. `flow.dispatcher.auth.enabled=false`
 (default `true`, `application.properties:34`) turns the filter into a pass-through for local development.
 The rest of `/api/v1/**` is `permitAll` and relies on network isolation.
 


### PR DESCRIPTION
Every authenticated request did two `findByToken` reads: `AuthenticationFilter` calls `tokenService.validate(token)` then `tokenService.get(token)` (`core/security/AuthenticationFilter.java:275-276`). Both now resolve through one positive-only lookup cache inside `TokenService`, the pattern the maintainer recorded as the target when the token model was restructured.

| What | Where |
| --- | --- |
| `TokenLookupCache` — Caffeine cache keyed by the stored SHA-256 hash (never the raw token), value = the validated `TokenEntity`; `get`/`put`/`evict`/`evictAll` | `core/security/TokenLookupCache.java` |
| `validate`, `get` and `validateActorToken` (the dispatcher path) read through one private `lookup`; only a present, unexpired entity is cached; misses are never cached; `expirationDate` is re-checked on every hit | `core/TokenService.java:411-423` |
| Eviction: `delete` evicts the hash; `deleteAllForPrincipal` flushes; `touchLastUsed` does not evict (throttle unchanged) | `core/TokenService.java:458-472` |
| Properties `flow.security.token-cache.enabled` (true), `.ttl` (60s), `.max-size` (10000) | `application.properties:21-25` |
| `AuthenticationFilter` | zero-line diff, so this does not conflict with #408 |

Semantics to know: eviction is per instance. After a revoke on one instance, another instance MAY still honour the token until its own entry ages out — at most the TTL. This is the same 60 s window the session-mint reuse already has, and it is now stated in `specifications/authorization.md:41-49`.

Dependency: `com.github.ben-manes.caffeine:caffeine`, version managed by the Spring Boot BOM (3.2.4). If a dependency is unwanted, the class boundary makes a `ConcurrentHashMap` of timestamped entries with a size cap a drop-in swap inside `TokenLookupCache` only.

Tests: `TokenServiceLookupCacheTest` (9) — validate-then-get hits the repository once, an unknown token is looked up every time, an expired token read from the repository is not cached, a cached token that has since expired is rejected, delete and deleteAllForPrincipal evict, disabled cache reads the repository on every call, `touchLastUsed` keeps the entry; `TokenServiceLookupCacheWiringTest` (1, Testcontainers). Full service-core suite: 397 run, 0 failures, 2 pre-existing skips.
